### PR TITLE
Replace flotr2 with Chart.js

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -42,9 +42,9 @@
     <script src="/bower_components/jquery/dist/jquery.js"></script>
     <script src="/bower_components/handlebars/handlebars.js"></script>
     <script src="/bower_components/sinon-browser-only/sinon.js"></script>
-    <script src="/bower_components/flotr2/flotr2.js"></script>
     <script src="/bower_components/markdown-it/dist/markdown-it.js"></script>
     <!-- endbower -->
+    <script src="/node_modules/chart.js/dist/chart.umd.js"></script>
     <!-- endbuild -->
 
     <!-- build:js scripts/main.js -->

--- a/app/scripts/charts/Burndown.js
+++ b/app/scripts/charts/Burndown.js
@@ -1,90 +1,60 @@
-class Burndown extends Charts{
-  constructor(el, yLabel){
+class Burndown extends Charts {
+  constructor(el) {
     super(el);
     this.conf = {
-      colors: this.clr.projection(),
-      HtmlText: false,
-      xaxis: {
-        minorTickFreq: 2,
-        title: 'Sprints',
-        showLabels: true,
-        showMinorLabels: true,
-        autoscale: true,
-        autoscaleMargin: 1,
-        showLabels: true,
-        tickDecimals: 0
-      },
-      yaxis: {
-        autoscale: true,
-        autoscaleMargin: 1,
-        tickDecimals: 0
-      },
-      grid: {
-        labelMargin: 5,
-        minorVerticalLines: true,
-        color: this.clr.grid(),
-        tickColor: this.clr.grid()
-      },
-      mouse : {
-        lineColor: this.clr.hover(),
-        sensibility: 30,
-        relative: true,
-        track : true
+      type: 'line',
+      data: { labels: [], datasets: [] },
+      options: {
+        scales: {
+          x: { ticks: { callback: (d) => this.tickFormatLabels(d) } },
+          y: { ticks: { precision: 0 } }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: { label: (ctx) => this.tooltipLabel(ctx) }
+          }
+        }
       }
     };
   }
-  makeDataLine(data, point, formatter){
-    let conf = {
-      'data': data,
-      'points' : {
-        'show' : (point) ? true : false,
-        'lineWidth': 1
-      },
-      'lines' : {
-        'show' : true,
-        'lineWidth': 1
-      },
-      'mouse': {}
-    };
-
-    if(formatter){
-      conf.mouse.trackFormatter = formatter;
-    } else {
-      conf.mouse.track = false;
+  tooltipLabel(ctx) {
+    if (ctx.datasetIndex === 0) {
+      return `Project Estimate: ${Math.round(ctx.parsed.y)}`;
     }
-
-    return conf;
+    return `${Math.round(ctx.parsed.y)} points completed in sprint ${ctx.dataIndex + 1}`;
   }
-  estimatedMouseOver(d){
-    return `Project Estimate: ${parseInt(d.y)}`;
-  }
-  completedMouseOver(d){
-    return `${parseInt(d.y)} points completed in sprint ${parseInt(d.x)}`;
-  }
-  processData(completed, estimated, predicted){
-    let arr = [];
-    if(estimated){
-      arr.push(this.makeDataLine(estimated, true, this.estimatedMouseOver));
-    }
-    arr.push(this.makeDataLine(completed, true, this.completedMouseOver));
-    if(predicted){
-      arr.push(this.makeDataLine(predicted, false));
-    }
-    return arr;
-  }
-  setData(data){
+  setData(data) {
     let count = 0;
-    let completed = [];
-    let estimated = [];
-    for(let i = 0; i < data[0].length; i++){
+    const completed = [];
+    const estimated = [];
+    for (let i = 0; i < data[0].length; i++) {
       count += data[0][i];
-      completed.push([i, count]);
-      estimated.push([i, data[1][i]]);
+      completed.push(count);
+      estimated.push(data[1][i]);
     }
-    this.data = this.processData(completed, estimated);
+    this.data = [
+      {
+        label: 'Estimated',
+        data: estimated,
+        borderColor: this.clr.projection()[0],
+        backgroundColor: 'transparent',
+        pointRadius: 3,
+        tension: 0
+      },
+      {
+        label: 'Completed',
+        data: completed,
+        borderColor: this.clr.projection()[1],
+        backgroundColor: 'transparent',
+        pointRadius: 3,
+        tension: 0
+      }
+    ];
+    this.conf.data.datasets = this.data;
   }
-  render(){
-    this.conf.xaxis.tickFormatter  = this.tickFormatLabels.bind(this);
+  render() {
+    this.conf.data.labels = this.labels;
     super.render();
   }
 }

--- a/app/scripts/charts/Charts.js
+++ b/app/scripts/charts/Charts.js
@@ -1,86 +1,83 @@
-class Charts{
-  constructor(el){
-    this.el = document.getElementById(el);
+class Charts {
+  constructor(el) {
+    const container = document.getElementById(el);
+    let canvas = container.querySelector('canvas');
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      container.appendChild(canvas);
+    }
+    this.el = canvas;
     this.clr = new Colors();
     this.labels = [];
     this.dates = [];
     this.notes = [];
     this.data = {};
     this.conf = {};
-    this.listener;
+    this.chartRef = null;
   }
-  getConf(){
+  getConf() {
     return this.conf;
   }
-  setConf(conf){
-    return this.conf = conf;
+  setConf(conf) {
+    this.conf = conf;
   }
-  setNotes(notes){
+  setNotes(notes) {
     this.notes = notes;
-    if(!this.listener){
-      this.listener = Flotr.EventAdapter.observe(
-        this.el,
-        'flotr:click',
-        this.getNoteMarkdown.bind(this)
-      );
-    }
   }
-  getNotes(notes){
+  getNotes() {
     return this.notes;
   }
-  getNoteIndex(position){
-    return this.chartRef.hit.hit(position).index;
-  }
-  getNoteMarkdown(position){
-    let index = this.getNoteIndex(position);
-    if(this.notes[index]){
-      return $.getJSON(
-        this.notes[index]
-      ).complete(
-        this.processResponse.bind(this)
-      );
+  getNoteMarkdown(index) {
+    if (this.notes[index]) {
+      return $.getJSON(this.notes[index]).complete(this.processResponse.bind(this));
     }
     return null;
   }
-  processResponse(data){
-    if(data.status === 200 && data.responseText){
-      let md = this.processMarkdown(data.responseText);
+  processResponse(data) {
+    if (data.status === 200 && data.responseText) {
       this.setHash('#notesDescription');
-      this.setMarkdownContent(md);
+      this.setMarkdownContent(this.processMarkdown(data.responseText));
     }
   }
-  processMarkdown(data){
-    let parser = new markdownit();
-    let md = parser.render(data);
-    return md;
+  processMarkdown(data) {
+    return new markdownit().render(data);
   }
-  setMarkdownContent(html){
+  setMarkdownContent(html) {
     $('#notesDescription .content').html(html);
   }
-  setHash(str){
+  setHash(str) {
     location.hash = str;
   }
-  setData(data){
+  setData(data) {
     this.data = data;
   }
-  getData(data){
+  getData() {
     return this.data;
   }
-  setLabels(labels){
+  setLabels(labels) {
     this.labels = labels;
   }
-  setDates(dates){
+  setDates(dates) {
     this.dates = dates;
   }
-  tickFormatLabels(d){
-    let label = (this.labels && this.labels.length > 0) ? this.labels[d] : d
-    return label || '';
+  tickFormatLabels(d) {
+    const i = parseInt(d, 10);
+    return (this.labels && this.labels.length > 0) ? (this.labels[i] || '') : d;
   }
-  tickFormatDates(d){
-    let dates = (this.dates && this.dates.length > 0) ? this.dates[d] : d;
-    return dates || '';
+  tickFormatDates(d) {
+    const i = parseInt(d, 10);
+    return (this.dates && this.dates.length > 0) ? (this.dates[i] || '') : d;
   }
-  render(){
-    this.chartRef = Flotr.draw(this.el, this.data, this.conf);
+  render() {
+    if (this.chartRef) { this.chartRef.destroy(); }
+    if (this.notes.length > 0) {
+      const options = this.conf.options = this.conf.options || {};
+      const prev = options.onClick;
+      options.onClick = (event, elements) => {
+        if (elements.length > 0) this.getNoteMarkdown(elements[0].index);
+        if (prev) prev(event, elements);
+      };
+    }
+    this.chartRef = new Chart(this.el, this.conf);
   }
 }

--- a/app/scripts/charts/Line.js
+++ b/app/scripts/charts/Line.js
@@ -1,62 +1,39 @@
-class Line extends Charts{
-  constructor(el, yLabel){
+class Line extends Charts {
+  constructor(el, yLabel) {
     super(el);
-    this.labels = [];
-    this.dates = [];
     this.yLabel = yLabel;
     this.conf = {
-      colors: [this.clr.todo()],
-      HtmlText: false,
-      yaxis: {
-        tickDecimals: 0,
-        margin: true,
-        autoscale: true,
-        title: 'Percentage',
-        autoscaleMargin: 1
-      },
-      xaxis: {
-        tickDecimals: 0,
-        margin: true,
-        autoscale: true,
-        autoscaleMargin: 1,
-        min: -0.1
-      },
-      grid: {
-        minorHorizontalLines: true,
-        verticalLines : false,
-        horizontalLines : true,
-        outlineWidth: 0,
-        color: this.clr.grid(),
-        tickColor: this.clr.grid()
-      },
-      mouse : {
-        lineColor: this.clr.hover(),
-        sensibility: 30,
-        relative: true,
-        track : false
+      type: 'line',
+      data: { labels: [], datasets: [] },
+      options: {
+        scales: {
+          x: { ticks: { callback: (d) => this.tickFormatLabels(d) } },
+          y: {
+            title: { display: true, text: 'Percentage' },
+            ticks: { precision: 0 }
+          }
+        },
+        plugins: { legend: { display: false } }
       }
     };
   }
-  setData(data){
-    let helper = new Helper();
-    let d1 = [];
-
-    for(let i = 0; i < data[0].data.length; i++){
-      d1.push([i, helper.calcPercentage(data[1].data[i] , data[0].data[i])]);
+  setData(data) {
+    const helper = new Helper();
+    const d1 = [];
+    for (let i = 0; i < data[0].data.length; i++) {
+      d1.push(helper.calcPercentage(data[1].data[i], data[0].data[i]));
     }
-
     this.data = [{
       data: d1,
-      lines: {
-        show: true
-      },
-      points: {
-        show: true
-      }
+      borderColor: this.clr.todo(),
+      backgroundColor: 'transparent',
+      pointRadius: 4,
+      tension: 0
     }];
+    this.conf.data.datasets = this.data;
   }
-  render(){
-    this.conf.xaxis.tickFormatter  = this.tickFormatLabels.bind(this);
+  render() {
+    this.conf.data.labels = this.labels;
     super.render();
   }
 }

--- a/app/scripts/charts/Lines.js
+++ b/app/scripts/charts/Lines.js
@@ -1,64 +1,34 @@
-class Lines extends Charts{
-  constructor(el, yLabel){
+class Lines extends Charts {
+  constructor(el, yLabel) {
     super(el);
-    this.labels = [];
-    this.dates = [];
     this.yLabel = yLabel;
     this.conf = {
-      colors: this.clr.getTheme(),
-      HtmlText: false,
-      yaxis: {
-        tickDecimals: 0,
-        margin: true,
-        autoscale: true,
-        autoscaleMargin: 0.5,
-        title: this.yLabel,
-        min: -1.5
-      },
-      xaxis: {
-        tickDecimals: 0,
-        margin: true,
-        autoscale: true,
-        autoscaleMargin: 0.5,
-        min: -0.5
-      },
-      grid: {
-        minorHorizontalLines: true,
-        verticalLines : false,
-        horizontalLines : true,
-        outlineWidth: 0,
-        color: this.clr.grid(),
-        tickColor: this.clr.grid()
-      },
-      mouse : {
-        lineColor: this.clr.hover(),
-        sensibility: 30,
-        relative: true,
-        track : false
+      type: 'line',
+      data: { labels: [], datasets: [] },
+      options: {
+        scales: {
+          x: { ticks: { callback: (d) => this.tickFormatLabels(d) } },
+          y: {
+            title: { display: !!yLabel, text: yLabel },
+            ticks: { precision: 0 }
+          }
+        }
       }
     };
   }
-  setData(data, names){
-    let d1 = [];
-    for(let d in data){
-      let label = names[d];
-      d1.push({
-        'data': data[d].map((val, idx) => {
-          return [idx, val];
-        }),
-        'label': label,
-        'lines': {
-          'show': true
-        },
-        'points': {
-          'show': true
-        }
-      });
-    }
-    this.data = d1;
+  setData(data, names) {
+    this.data = Object.keys(data).map((key, idx) => ({
+      label: names[key],
+      data: data[key],
+      borderColor: this.clr.getTheme()[idx],
+      backgroundColor: 'transparent',
+      pointRadius: 4,
+      tension: 0
+    }));
+    this.conf.data.datasets = this.data;
   }
-  render(){
-    this.conf.xaxis.tickFormatter  = this.tickFormatLabels.bind(this);
+  render() {
+    this.conf.data.labels = this.labels;
     super.render();
   }
 }

--- a/app/scripts/charts/Pie.js
+++ b/app/scripts/charts/Pie.js
@@ -1,64 +1,45 @@
-class Pie extends Charts{
-  constructor(el, mLabel = 'points'){
+class Pie extends Charts {
+  constructor(el, mLabel = 'points') {
     super(el);
     this.mLabel = mLabel;
     this.conf = {
-      colors: this.clr.getTheme(),
-      HtmlText : false,
-      grid : {
-        verticalLines : false,
-        horizontalLines : false,
-        outlineWidth: 0
+      type: 'pie',
+      data: {
+        labels: [],
+        datasets: [{ data: [], backgroundColor: [] }]
       },
-      xaxis : {
-        showLabels : false
-      },
-      yaxis : {
-        showLabels : false
-      },
-      pie : {
-        show : true,
-        explode : 6,
-        startAngle: .73,
-        lineWidth: 2
-      },
-      mouse : {
-        track : true,
-        lineColor: this.clr.hover()
-      },
-      legend : {
-        position : 'nw',
-        backgroundColor : null,
-        labelBoxBorderColor: this.clr.legend()
+      options: {
+        plugins: {
+          legend: { position: 'left' },
+          tooltip: {
+            callbacks: { label: (ctx) => this.formatTooltip(ctx) }
+          }
+        }
       }
     };
   }
-  formatTickLabelPoint(d){
-    return `${d.series.label} ${Math.round(d.y)} ${this.mLabel}`;
+  formatTooltip(ctx) {
+    return `${ctx.label} ${Math.round(ctx.parsed)} ${this.mLabel}`;
   }
-  formatMouselabelPoint(d){
-    return `${d.series.label} ${Math.round(d.y)} ${this.mLabel}`;
-  };
-  setTypeValue(label){
+  setTypeValue(label) {
     this.mLabel = label;
   }
-  setData(data){
-    let status = [];
-    let count = 0;
-
-    for(let name in data){
-      if(data[name] > 0){
-        status.push({
-          'data' : [[count++, data[name]]],
-          'label' : name
-        });
+  getColors() {
+    return this.clr.getTheme();
+  }
+  setData(data) {
+    this.data = [];
+    for (let name in data) {
+      if (data[name] > 0) {
+        this.data.push({ label: name, value: data[name] });
       }
     }
-
-    this.data = status;
+    const colors = this.getColors();
+    this.conf.data.labels = this.data.map(d => d.label);
+    this.conf.data.datasets[0].data = this.data.map(d => d.value);
+    this.conf.data.datasets[0].backgroundColor = colors.slice(0, this.data.length);
   }
-  render(){
-    this.conf.mouse.trackFormatter  = this.formatMouselabelPoint.bind(this);
+  render() {
     super.render();
   }
 }

--- a/app/scripts/charts/Satisfaction.js
+++ b/app/scripts/charts/Satisfaction.js
@@ -1,81 +1,51 @@
-class Satisfaction extends Charts{
-  constructor(el){
+class Satisfaction extends Charts {
+  constructor(el) {
     super(el);
     this.conf = {
-      colors: this.clr.getTheme(),
-      HtmlText: false,
-      yaxis: {
-        title           : 'Score 1-10',
-        tickDecimals    : 0,
-        max             : 10.5,
-        min             : .5
-      },
-      xaxis: {
-        title           : 'Sprint Date',
-        tickDecimals    : 0,
-        min             : -0.1
-      },
-      grid: {
-        tickDecimals    : 0,
-        verticalLines   : false,
-        horizontalLines : true,
-        outlineWidth    : 0,
-        color           : this.clr.grid(),
-        tickColor       : this.clr.grid()
-      },
-      mouse : {
-        lineColor       : this.clr.hover(),
-        sensibility     : 30,
-        relative        : true,
-        track           : true
-      },
-      legend: {
-        show               : true,
-        position           : 'ne',
-        labelBoxBorderColor: this.clr.legend(),
-        backgroundColor    : this.clr.background(),
-        backgroundOpacity  : 0.75
+      type: 'scatter',
+      data: { datasets: [] },
+      options: {
+        scales: {
+          x: {
+            title: { display: true, text: 'Sprint Date' },
+            ticks: {
+              callback: (d) => this.tickFormatDates(d),
+              precision: 0
+            }
+          },
+          y: {
+            title: { display: true, text: 'Score 1-10' },
+            min: 0.5,
+            max: 10.5,
+            ticks: { precision: 0 }
+          }
+        },
+        plugins: {
+          legend: { position: 'top' },
+          tooltip: {
+            callbacks: { label: (ctx) => this.trackFormatter(ctx) }
+          }
+        }
       }
     };
   }
-  tickFormatter(d){
-    return (this.dates && this.dates.length > 0) ? this.dates[d] : d;
-  }
-  trackFormatter(d){
-    let message = '';
-    let label = (this.labels && this.labels.length > 0) ? this.labels[d.index] : d ;
-    let date = (this.dates && this.dates.length > 0) ? this.dates[d.index] : d ;
-    if(d.y === 0){
-      message += 'No Voters!';
-    } else {
-      message += `Score: ${d.y}`;
-    }
+  trackFormatter(ctx) {
+    const index = ctx.dataIndex !== undefined ? ctx.dataIndex : ctx.index;
+    const label = (this.labels && this.labels.length > 0) ? this.labels[index] : index;
+    const date = (this.dates && this.dates.length > 0) ? this.dates[index] : index;
+    const score = ctx.parsed ? ctx.parsed.y : ctx.y;
+    const message = score === 0 ? 'No Voters!' : `Score: ${score}`;
     return `Date: ${date}<br>Interval: ${label}<br>${message}`;
   }
-  setData(data){
-    let newData = data.map((val) => {
-      return {
-        'label'      : val.label,
-        'data'       : val.scores.map((val,idx,arr) => {
-          return [idx,val];
-        }),
-        'lines'      : {
-          'show'     : false
-        },
-        'points'     : {
-          'show'     : true,
-          'radius'   : 4,
-          'fill'     : false,
-          'lineWidth': 8,
-          'fillColor': this.clr.background()
-        }
-      };
-    });
-    this.data = newData;
-  }
-  render(){
-    this.conf.mouse.trackFormatter = this.trackFormatter.bind(this);
-    this.conf.xaxis.tickFormatter  = this.tickFormatter.bind(this);
-    super.render();
+  setData(data) {
+    this.data = data.map((val, idx) => ({
+      label: val.label,
+      data: val.scores.map((score, i) => ({ x: i, y: score })),
+      borderColor: this.clr.getTheme()[idx],
+      backgroundColor: 'transparent',
+      pointRadius: 8,
+      showLine: false
+    }));
+    this.conf.data.datasets = this.data;
   }
 }

--- a/app/scripts/charts/Status.js
+++ b/app/scripts/charts/Status.js
@@ -1,13 +1,9 @@
-class Status extends Pie{
-  constructor(el, mLabel = 'points'){
+class Status extends Pie {
+  constructor(el, mLabel = 'points') {
     super(el);
-    this.conf.colors = this.clr.progress();
     this.mLabel = mLabel;
   }
-  setData(data){
-    super.setData(data);
-  }
-  render(){
-    super.render();
+  getColors() {
+    return this.clr.progress();
   }
 }

--- a/app/scripts/charts/Timelines.js
+++ b/app/scripts/charts/Timelines.js
@@ -1,70 +1,39 @@
-class Timelines extends Charts{
-  constructor(el){
+class Timelines extends Charts {
+  constructor(el) {
     super(el);
-    this.barLabels = [];
     this.conf = {
-      timeline: {
-        barWidth: .95,
-        show:true,
-      },
-      markers: {
-        show: true,
-        position: 'rm',
-        fontSize: 9,
-        stacked: true,
-        stackingType: 'a',
-        color: this.clr.grid()
-      },
-      xaxis: {
-        title: 'Sprint',
-        noTicks: 10,
-        tickDecimals: 0
-      },
-      yaxis: {
-        showLabels : false
-      },
-      grid: {
-        horizontalLines : false,
-        color: this.clr.grid(),
-        tickColor: this.clr.grid()
+      type: 'bar',
+      data: { labels: [], datasets: [] },
+      options: {
+        indexAxis: 'y',
+        scales: {
+          x: {
+            title: { display: true, text: 'Sprint' },
+            ticks: { callback: (d) => this.intervalFormatter(d) }
+          }
+        },
+        plugins: { legend: { display: false } }
       }
     };
   }
-  labelFormatter(d){
-    // Stacked bars text
-    return this.barLabels[d.y];
+  intervalFormatter(d) {
+    return this.labels[parseInt(d, 10)] || '';
   }
-  intervalFormatter(d){
-    // Intervals on the bottom text
-    let num = parseInt(d, 10);
-    let label = this.labels[num] || 'N/A';
-    return label || '';
+  processBarLabels(data) {
+    return data.map(item => item.label);
   }
-  processData(data){
-    return data.map((item, index) => {
-      let color = this.clr.statusToColor(item.status);
-      return {
-        color: color,
-        data: [[
-          (parseInt(item.start, 10) * 0.1),
-          index,
-          (parseInt(item.days, 10) * 0.1)
-        ]]
-      }
-    });
-  }
-  processBarLabels(data){
-    return data.map((item) => {
-      return item.label;
-    });
-  }
-  setData(data){
-    this.barLabels = this.processBarLabels(data);
-    this.data = this.processData(data);
-  }
-  render(){
-    this.conf.markers.labelFormatter = this.labelFormatter.bind(this);
-    this.conf.xaxis.tickFormatter = this.intervalFormatter.bind(this);
-    super.render();
+  setData(data) {
+    this.data = data.map(item => ({
+      label: item.label,
+      start: parseInt(item.start, 10) * 0.1,
+      end: (parseInt(item.start, 10) + parseInt(item.days, 10)) * 0.1,
+      color: this.clr.statusToColor(item.status)
+    }));
+    this.conf.data.labels = this.data.map(d => d.label);
+    this.conf.data.datasets = [{
+      data: this.data.map(d => [d.start, d.end]),
+      backgroundColor: this.data.map(d => d.color),
+      borderWidth: 0
+    }];
   }
 }

--- a/app/scripts/charts/TwoBars.js
+++ b/app/scripts/charts/TwoBars.js
@@ -1,74 +1,43 @@
-class TwoBars extends Charts{
-  constructor(el, yLabel){
+class TwoBars extends Charts {
+  constructor(el, yLabel) {
     super(el);
-    this.labels = [];
-    this.dates = [];
     this.yLabel = yLabel;
     this.conf = {
-      colors: this.clr.progress(true).reverse().copyWithin(0,1),
-      HtmlText: false,
-      bars : {
-        show : true,
-        horizontal : false,
-        barWidth: .9,
-        lineWidth: 2
-      },
-      mouse : {
-        track : true,
-        relative : true,
-        lineColor: this.clr.hover()
-      },
-      xaxis : {
-        tickDecimals: 0,
-        title: 'Sprint',
-        titleAngle: 0,
-      },
-      yaxis : {
-        min : 0,
-        autoscaleMargin : 1,
-        tickDecimals: 0,
-        title: this.yLabel,
-        titleAngle: 90
-      },
-      grid: {
-        verticalLines: false,
-        color: this.clr.grid(),
-        tickColor: this.clr.grid()
-      },
-      legend: {
-        show: true
+      type: 'bar',
+      data: { labels: [], datasets: [] },
+      options: {
+        scales: {
+          x: { ticks: { callback: (d) => this.tickFormatLabels(d) } },
+          y: {
+            min: 0,
+            title: { display: !!yLabel, text: yLabel },
+            ticks: { precision: 0 }
+          }
+        },
+        plugins: {
+          legend: { display: true },
+          tooltip: {
+            callbacks: { label: (ctx) => this.tooltip(ctx) }
+          }
+        }
       }
     };
   }
-  tooltip(obj){
-    return `${obj.series.label} ${Math.round(obj.y)} ${this.yLabel.toLowerCase()} for ${this.labels[obj.index]}`;
+  tooltip(ctx) {
+    const label = this.labels[ctx.dataIndex] || ctx.dataIndex;
+    return `${ctx.dataset.label} ${Math.round(ctx.parsed.y)} ${this.yLabel.toLowerCase()} for ${label}`;
   }
-  tickFormatLabels(d){
-    let num = parseInt(d,10) + 1;
-    let sprint = [0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,
-      10,10,11,11,12,12,13,13,14,14,15,15,16,16,17,17,18,18,19,19,20,20];
-    let tick = (num%2 === 0) ? num +1 : num;
-    return (this.labels && this.labels.length > 0) ? this.labels[sprint[tick]] : sprint[tick];
+  setData(data) {
+    const colors = this.clr.progress(true).reverse().copyWithin(0, 1);
+    this.data = data.map((val, idx) => ({
+      label: val.label,
+      data: val.data,
+      backgroundColor: colors[idx]
+    }));
+    this.conf.data.datasets = this.data;
   }
-  setData(data){
-    let newData = data.map((val, idx) => {
-      let even = (idx % 2);
-      return {
-        'label'      : val.label,
-        'data'       : val.data.map((val,idx,arr) => {
-          let i = idx * 2;
-          if(!even){
-            i--;
-          }
-          return [i,val];
-        })
-      };
-    });
-    this.data = newData;
-  }
-  render(){
-    this.conf.mouse.trackFormatter = this.tooltip.bind(this);
-    this.conf.xaxis.tickFormatter  = this.tickFormatLabels.bind(this);
+  render() {
+    this.conf.data.labels = this.labels;
     super.render();
   }
 }

--- a/app/scripts/charts/Types.js
+++ b/app/scripts/charts/Types.js
@@ -1,12 +1,6 @@
-class Types extends Pie{
-  constructor(el, mLabel = 'points'){
+class Types extends Pie {
+  constructor(el, mLabel = 'points') {
     super(el);
     this.mLabel = mLabel;
-  }
-  setData(data){
-    super.setData(data);
-  }
-  render(){
-    super.render();
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
     "handlebars": "^4.7.8",
     "skeleton": "^2.0.4",
     "sinon-browser-only": "^1.17.1",
-    "flotr2": "*",
     "markdown-it": "^8.2.2"
   },
   "devDependencies": {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -125,7 +125,7 @@ gulp.task('serve', gulp.series(
       port: 9000,
       server: {
         baseDir: ['.tmp', 'app'],
-        routes: { '/bower_components': 'bower_components' }
+        routes: { '/bower_components': 'bower_components', '/node_modules': 'node_modules' }
       }
     });
 
@@ -158,7 +158,8 @@ gulp.task('serve:test', gulp.series(
         routes: {
           '/scripts': '.tmp/scripts',
           '/templates': '.tmp/templates',
-          '/bower_components': 'bower_components'
+          '/bower_components': 'bower_components',
+          '/node_modules': 'node_modules'
         }
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "chart.js": "^4.5.1"
+      },
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.5",
@@ -2337,6 +2340,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3443,6 +3452,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5"
+  },
+  "dependencies": {
+    "chart.js": "^4.5.1"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,6 @@
   <!-- bower:js -->
   <script src="../bower_components/sinon-browser-only/sinon.js"></script>
   <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/flotr2/flotr2.min.js"></script>
   <script src="../bower_components/handlebars/handlebars.js"></script>
   <script src="../bower_components/markdown-it/dist/markdown-it.js"></script>
   <!---->
@@ -33,6 +32,7 @@
   </script>
 
   <!-- endbower -->
+  <script src="../node_modules/chart.js/dist/chart.umd.js"></script>
   <script src="data.js"></script>
   <script src="templates/main.js"></script>
   <script src="templates/partials/dashboardHeader.js"></script>

--- a/test/node-runner.js
+++ b/test/node-runner.js
@@ -34,11 +34,11 @@ global.should = chai.should();
 const sinon  = require('sinon');
 global.sinon = sinon;
 
-// --- Flotr stub (canvas charting library — not usable in jsdom) ---
-global.Flotr = {
-  draw: () => ({ hit: { hit: () => ({ index: 0 }) } }),
-  EventAdapter: { observe: () => {} }
+// --- Chart.js stub (canvas charting library — not usable in jsdom) ---
+global.Chart = function Chart(el, conf) {
+  this.destroy = function() {};
 };
+global.Chart.register = function() {};
 
 // --- markdown-it (pure-JS UMD build from bower) ---
 global.markdownit = require(

--- a/test/spec/charts/Burndown.js
+++ b/test/spec/charts/Burndown.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Burndown('charts');
     });
     afterEach(() => {
@@ -11,110 +11,32 @@
     });
 
     describe('The Burndown chart', () => {
-      it('should makeDataLine false', function () {
-        let results = chart.makeDataLine([0,1], false);
-
-        expect(results).to.eql({
-          'data': [0,1],
-          'points' : {
-            'show' : false,
-            'lineWidth': 1
-          },
-          'lines' : {
-            'show' : true,
-            'lineWidth': 1
-          },
-          'mouse': {
-            'track': false
-          }
-        });
+      it('should have line chart type', function () {
+        expect(chart.conf.type).to.eql('line');
+        expect(chart.conf.options.scales.y.ticks.precision).to.eql(0);
       });
-      it('should makeDataLine true', function () {
-        let results = chart.makeDataLine([0,1], true);
-
-        expect(results).to.eql({
-          'data': [0,1],
-          'points' : {
-            'show' : true,
-            'lineWidth': 1
-          },
-          'lines' : {
-            'show' : true,
-            'lineWidth': 1
-          },
-          'mouse': {
-            'track': false
-          }
-        });
+      it('should format tooltip for estimated series', function () {
+        expect(chart.tooltipLabel({ datasetIndex: 0, parsed: { y: 5 }, dataIndex: 0 }))
+          .to.eql('Project Estimate: 5');
       });
-      it('should makeDataLine true with formater', function () {
-        let formatter = () => {};
-        let results = chart.makeDataLine([0,1], true, formatter);
-
-        expect(results).to.eql({
-          'data': [0,1],
-          'points' : {
-            'show' : true,
-            'lineWidth': 1
-          },
-          'lines' : {
-            'show' : true,
-            'lineWidth': 1
-          },
-          'mouse': {
-            'trackFormatter': formatter
-          }
-        });
-      });
-      it('should estimatedMouseOver', function () {
-        chart.setData([[20,25,25,30],[5,12,18,22]]);
-        let d = chart.getData();
-        let f1 = d[0].mouse.trackFormatter({ 'y': '5'});
-        expect(f1).to.eql('Project Estimate: 5');
-      });
-      it('should completedMouseOver', function () {
-        chart.setData([[20,25,25,30],[5,12,18,22]]);
-        let d = chart.getData();
-        let f1 = d[1].mouse.trackFormatter({ 'x': '5', 'y': 10});
-        expect(f1).to.eql('10 points completed in sprint 5');
-      });
-      it('should processData', function () {
-        let result = chart.processData([[0,5],[1,12],[2,18],[3,22]], null ,[[0,20],[1,45],[2,70],[3,100]]);
-        let d = chart.getData();
-        expect(result[1].data).to.eql([[0,20],[1,45],[2,70],[3,100]]);
-      });
-      it('should have the correct default configuration', function () {
-        expect(chart.conf.xaxis.title).to.eql('Sprints');
-        expect(chart.conf.xaxis.tickDecimals).to.eql(0);
-        expect(chart.conf.yaxis.tickDecimals).to.eql(0);
-        expect(chart.conf.mouse.relative).to.eql(true);
+      it('should format tooltip for completed series', function () {
+        expect(chart.tooltipLabel({ datasetIndex: 1, parsed: { y: 10 }, dataIndex: 4 }))
+          .to.eql('10 points completed in sprint 5');
       });
       it('should render without throwing', function () {
         chart.setData([[10, 20], [5, 15]]);
         expect(() => chart.render()).to.not.throw();
       });
       it('should have the correct data', function () {
-        chart.setData([[20,25,25,30],[5,12,18,22]]);
-        let d = chart.getData();
-        expect(d[0].points).to.eql({
-          'show' : true,
-          'lineWidth': 1
-        });
-        expect(d[1].points).to.eql({
-          'show' : true,
-          'lineWidth': 1
-        });
-        expect(d[0].lines).to.eql({
-          'show' : true,
-          'lineWidth': 1
-        });
-        expect(d[1].lines).to.eql({
-          'show' : true,
-          'lineWidth': 1
-        });
-        expect(d[0].data).to.eql([[0,5],[1,12],[2,18],[3,22]]);
-        expect(d[1].data).to.eql([[0,20],[1,45],[2,70],[3,100]]);
-
+        chart.setData([[20, 25, 25, 30], [5, 12, 18, 22]]);
+        const d = chart.getData();
+        expect(d[0].data).to.eql([5, 12, 18, 22]);
+        expect(d[1].data).to.eql([20, 45, 70, 100]);
+      });
+      it('should accumulate completed points', function () {
+        chart.setData([[10, 5, 15], [30, 30, 30]]);
+        const d = chart.getData();
+        expect(d[1].data).to.eql([10, 15, 30]);
       });
     });
 

--- a/test/spec/charts/Charts.js
+++ b/test/spec/charts/Charts.js
@@ -4,7 +4,7 @@
   let charts;
     beforeEach(() => {
       $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
-        charts = new Charts('charts');
+      charts = new Charts('charts');
     });
     afterEach(() => {
       $('#sandbox #charts').remove();
@@ -39,35 +39,25 @@
     });
     describe('The Charts', () => {
       it('should set the config object', () => {
-        const conf = {
-          'hello':'world'
-        };
+        const conf = { 'hello':'world' };
         charts.setConf(conf);
         expect(charts.getConf()).to.eql(conf);
       });
       it('should set the data object', () => {
-        const data = {
-          'hello':'world'
-        };
+        const data = { 'hello':'world' };
         charts.setData(data);
         expect(charts.getData()).to.eql(data);
       });
-      it('should set the data object', () => {
-        sinon.spy(Flotr, 'draw');
-        const data = {
-          'hello':'world'
-        };
-        const conf = {
-          'hello':'world'
-        };
-        charts.setConf(conf);
-        charts.setData(data);
+      it('should set chartRef on render', () => {
         charts.render();
-        const expected = Flotr.draw.getCall(0).args;
-        expect(expected[0].id).to.eql('charts');
-        expect(expected[1]).to.eql(data);
-        expect(expected[2]).to.eql(conf);
-        Flotr.draw.restore();
+        expect(charts.chartRef).to.not.equal(null);
+      });
+      it('should destroy previous chart on re-render', () => {
+        charts.render();
+        let destroyed = false;
+        charts.chartRef.destroy = () => { destroyed = true; };
+        charts.render();
+        expect(destroyed).to.be.true;
       });
       it('should set the labels prop for tick format', () => {
         const labels = ['bob', 'tim', 'sue'];
@@ -81,47 +71,23 @@
         charts.setNotes(notes);
         expect(charts.getNotes()).to.eql(notes);
       });
-      it('should set the notes from the server', () => {
+      it('should fetch note when note exists at index', () => {
         const notes = ['note/url/1', null, 'note/url/3'];
         charts.setNotes(notes);
-        charts.render();
-
-        let stub = sinon.stub(charts.chartRef.hit, 'hit');
-        stub.onCall(0).returns({ 'index': 0});
-
         let result = charts.getNoteMarkdown(0);
         expect(result).to.be.an('object');
       });
-      it('should set the notes from the server with null', () => {
+      it('should return null when note is missing at index', () => {
         const notes = ['note/url/1', null, 'note/url/3'];
         charts.setNotes(notes);
-        charts.render();
-
-        let stub = sinon.stub(charts.chartRef.hit, 'hit');
-        stub.onCall(0).returns({ 'index': 1});
-
-        let result = charts.getNoteMarkdown(0);
+        let result = charts.getNoteMarkdown(1);
         expect(result).to.eql(null);
       });
-      it('should create one listener for notes', () => {
-        sinon.spy(Flotr.EventAdapter, 'observe');
-        const data = {
-          'hello':'world'
-        };
-        const conf = {
-          'hello':'world'
-        };
+      it('should add onClick handler when notes are set', () => {
         const notes = ['# note 1', null, '# note 3'];
-        charts.setConf(conf);
-        charts.setData(data);
         charts.setNotes(notes);
         charts.render();
-        charts.setNotes(notes);
-        const expected = Flotr.EventAdapter.observe.getCall(0);
-        expect(expected.args[0].getAttribute('id')).to.eql('charts');
-        expect(expected.args[1]).to.eql('flotr:click');
-        expect(expected.args[2].name).to.eql('bound getNoteMarkdown');
-        Flotr.EventAdapter.observe.restore();
+        expect(typeof charts.conf.options.onClick).to.eql('function');
       });
       it('should set the dates prop for tick format', () => {
         const dates = ['11/6', '12/6', '01/6'];
@@ -131,17 +97,12 @@
         expect(charts.tickFormatDates(2)).to.eql('01/6');
       });
       it('should set the processMarkdown method', () => {
-        const notes = ['# note 1', null, '# note 3'];
         let data = charts.processMarkdown('# note 1');
         expect(data.replace(/(\r\n|\n|\r)/gm,'')).to.eql('<h1>note 1</h1>');
       });
       it('should set the location hash', () => {
         charts.setHash('#test');
         expect(location.hash).to.eql('#test');
-      });
-      it('should get the note index from the chart reference', () => {
-        charts.render();
-        expect(charts.getNoteIndex({})).to.eql(0);
       });
     });
 

--- a/test/spec/charts/Line.js
+++ b/test/spec/charts/Line.js
@@ -1,9 +1,9 @@
 (function () {
   'use strict';
 
-  let chart, helper;
+  let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Line('charts');
     });
     afterEach(() => {
@@ -11,16 +11,16 @@
     });
 
     describe('The Line chart', () => {
-      it('should have the correct default configuration', function () {
-        expect(chart.conf.yaxis.title).to.eql('Percentage');
-        expect(chart.conf.grid.verticalLines).to.eql(false);
+      it('should have line chart type with Percentage y-axis', function () {
+        expect(chart.conf.type).to.eql('line');
+        expect(chart.conf.options.scales.y.title.text).to.eql('Percentage');
       });
       it('should handle zero values', function () {
         chart.setData([
           { label: 'Commited', data: [0] },
           { label: 'Completed', data: [0] }
         ]);
-        expect(chart.getData()[0].data).to.eql([[0, 0]]);
+        expect(chart.getData()[0].data).to.eql([0]);
       });
       it('should render without throwing', function () {
         chart.setData([
@@ -29,23 +29,16 @@
         ]);
         expect(() => chart.render()).to.not.throw();
       });
-      it('should format data', function () {
+      it('should format data as percentage values', function () {
         chart.setData([{
             label: 'Completed',
-            data: [2,3,4,5]
+            data: [2, 3, 4, 5]
           },{
             label: 'Commited',
-            data: [5,2,7,5]
+            data: [5, 2, 7, 5]
         }]);
-        let d = chart.getData()[0];
-        expect(d.lines.show).to.eql(true);
-        expect(d.points.show).to.eql(true);
-        expect(d.data).to.eql([
-          [0,250],
-          [1,67],
-          [2,175],
-          [3,100]
-        ]);
+        const d = chart.getData()[0];
+        expect(d.data).to.eql([250, 67, 175, 100]);
       });
     });
 

--- a/test/spec/charts/Lines.js
+++ b/test/spec/charts/Lines.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Lines('charts');
     });
     afterEach(() => {
@@ -11,7 +11,7 @@
     });
 
     describe('The Lines chart', () => {
-      it('should format each series as indexed [x, y] pairs', function () {
+      it('should format each series with flat data arrays', function () {
         chart.setData({
           'daysWorked': [10, 12, 8],
           'daysTimebox': [1, 0, 2]
@@ -19,11 +19,9 @@
           'daysWorked': 'Capacity',
           'daysTimebox': 'Timeboxes'
         });
-        let d = chart.getData();
+        const d = chart.getData();
         expect(d[0].label).to.eql('Capacity');
-        expect(d[0].data).to.eql([[0, 10], [1, 12], [2, 8]]);
-        expect(d[0].lines.show).to.eql(true);
-        expect(d[0].points.show).to.eql(true);
+        expect(d[0].data).to.eql([10, 12, 8]);
       });
       it('should render without throwing', function () {
         chart.setData({ 'a': [1, 2] }, { 'a': 'Label' });
@@ -37,10 +35,10 @@
           'a': 'Series A',
           'b': 'Series B'
         });
-        let d = chart.getData();
+        const d = chart.getData();
         expect(d.length).to.eql(2);
         expect(d[1].label).to.eql('Series B');
-        expect(d[1].data).to.eql([[0, 3], [1, 4]]);
+        expect(d[1].data).to.eql([3, 4]);
       });
     });
 

--- a/test/spec/charts/Pie.js
+++ b/test/spec/charts/Pie.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
     });
     afterEach(() => {
       $('#sandbox #charts').remove();
@@ -13,27 +13,13 @@
       beforeEach(() => {
         chart = new Pie('charts', 'Cat');
       });
-      it('should formatTickLabelPoint to return with label', function () {
-        let result = chart.formatTickLabelPoint({
-          'y': '220.123',
-          'series': { 'label': 'Bob' }
-        });
+      it('should formatTooltip with label and value', function () {
+        let result = chart.formatTooltip({ label: 'Bob', parsed: 220.123 });
         expect(result).to.eql('Bob 220 Cat');
       });
-      it('should formatMouselabelPoint to return with label', function () {
-        let result = chart.formatMouselabelPoint({
-          'y': '20',
-          'series': { 'label': 'Bill' }
-        });
-        expect(result).to.eql('Bill 20 Cat');
-      });
-      it('should formatMouselabelPoint to return with label', function () {
-        let result;
+      it('should formatTooltip after setTypeValue', function () {
         chart.setTypeValue('Cow');
-        result = chart.formatMouselabelPoint({
-          'y': '30',
-          'series': { 'label': 'Bee' }
-        });
+        let result = chart.formatTooltip({ label: 'Bee', parsed: 30 });
         expect(result).to.eql('Bee 30 Cow');
       });
     });
@@ -42,48 +28,25 @@
       beforeEach(() => {
         chart = new Pie('charts');
       });
-      it('should Configuration to have', function () {
-        expect(chart.conf.HtmlText).to.eql(false);
-        expect(chart.conf.grid).to.eql({
-          verticalLines : false,
-          horizontalLines : false,
-          outlineWidth: 0
-        });
-        expect(chart.conf.xaxis).to.eql({
-          showLabels : false
-        });
-        expect(chart.conf.yaxis).to.eql({
-          showLabels : false
-        });
-        expect(chart.conf.pie).to.eql({
-          show : true,
-          explode : 6,
-          startAngle: .73,
-          lineWidth: 2
-        });
+      it('should have pie chart type', function () {
+        expect(chart.conf.type).to.eql('pie');
       });
-      it('should formatTickLabelPoint to return', function () {
-        let result = chart.formatTickLabelPoint({
-          'y': '10.123',
-          'series': { 'label': 'Tim' }
-        });
+      it('should formatTooltip with default label', function () {
+        let result = chart.formatTooltip({ label: 'Tim', parsed: 10.123 });
         expect(result).to.eql('Tim 10 points');
       });
-      it('should set data', function () {
+      it('should set data filtering out zero values', function () {
         chart.setData({
-    			'In-Progress': 10,
-          'Verifing': 0,
-    			'Done': 20
-    		});
+          'In-Progress': 10,
+          'Verifying': 0,
+          'Done': 20
+        });
         expect(chart.data).to.eql([
-          {
-            'data' : [[0, 10]],
-            'label' : 'In-Progress'
-          },{
-            'data' : [[1, 20]],
-            'label' : 'Done'
-          }
+          { label: 'In-Progress', value: 10 },
+          { label: 'Done', value: 20 }
         ]);
+        expect(chart.conf.data.labels).to.eql(['In-Progress', 'Done']);
+        expect(chart.conf.data.datasets[0].data).to.eql([10, 20]);
       });
     });
 

--- a/test/spec/charts/Satisfaction.js
+++ b/test/spec/charts/Satisfaction.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Satisfaction('charts');
     });
     afterEach(() => {
@@ -13,71 +13,39 @@
     describe('The Satisfaction chart', () => {
       it('should format the tick as the date at that index', function () {
         chart.setDates(['2/22/2000', '3/1/2001']);
-        expect(chart.tickFormatter(0)).to.eql('2/22/2000');
-        expect(chart.tickFormatter(1)).to.eql('3/1/2001');
+        expect(chart.tickFormatDates(0)).to.eql('2/22/2000');
+        expect(chart.tickFormatDates(1)).to.eql('3/1/2001');
       });
       it('should return the raw index when no dates are set', function () {
-        expect(chart.tickFormatter(5)).to.eql(5);
+        expect(chart.tickFormatDates(5)).to.eql(5);
       });
       it('should render without throwing', function () {
         chart.setData([{ label: 'team', scores: [5, 7] }]);
         expect(() => chart.render()).to.not.throw();
       });
-      it('should format data', function () {
-        chart.setLabels(['Spint 1']);
+      it('should format tooltip with score', function () {
+        chart.setLabels(['Sprint 1']);
         chart.setDates(['2/22/2000']);
-        let result = chart.trackFormatter({
-          'index': 0,
-          'y': 2.5
-        });
-        expect(result).to.eql('Date: 2/22/2000<br>Interval: Spint 1<br>Score: 2.5');
+        let result = chart.trackFormatter({ dataIndex: 0, parsed: { y: 2.5 } });
+        expect(result).to.eql('Date: 2/22/2000<br>Interval: Sprint 1<br>Score: 2.5');
       });
-      it('should format data', function () {
-        chart.setLabels(['Spint 1']);
+      it('should format tooltip with no voters', function () {
+        chart.setLabels(['Sprint 1']);
         chart.setDates(['2/22/2000']);
-        let result = chart.trackFormatter({
-          'index': 0,
-          'y': 0
-        });
-        expect(result).to.eql('Date: 2/22/2000<br>Interval: Spint 1<br>No Voters!');
+        let result = chart.trackFormatter({ dataIndex: 0, parsed: { y: 0 } });
+        expect(result).to.eql('Date: 2/22/2000<br>Interval: Sprint 1<br>No Voters!');
       });
-      it('should format data', function () {
-        let result = [{
-          'label'      : 'team',
-          'data'       : [[0,[0,1]],[1,[1,2]]],
-          'lines'      : {
-            'show'     : false
-          },
-          'points'     : {
-            'show'     : true,
-            'radius'   : 4,
-            'fill'     : false,
-            'lineWidth': 8,
-            'fillColor': '#ffffff'
-          }
-        },{
-          'label'      : 'shareholder',
-          'data'       : [[0,[0,3]],[1,[1,4]]],
-          'lines'      : {
-            'show'     : false
-          },
-          'points'     : {
-            'show'     : true,
-            'radius'   : 4,
-            'fill'     : false,
-            'lineWidth': 8,
-            'fillColor': '#ffffff'
-          }
-        }];
-        let data = [{
-          'label': 'team',
-          'scores': [[0,1],[1,2]]
-        },{
-          'label': 'shareholder',
-          'scores': [[0,3],[1,4]]
-        }];
+      it('should format data as scatter points', function () {
+        const data = [
+          { label: 'team', scores: [5, 8] },
+          { label: 'shareholder', scores: [3, 7] }
+        ];
         chart.setData(data);
-        expect(chart.getData()).to.eql(result);
+        const d = chart.getData();
+        expect(d[0].label).to.eql('team');
+        expect(d[0].data).to.eql([{ x: 0, y: 5 }, { x: 1, y: 8 }]);
+        expect(d[1].label).to.eql('shareholder');
+        expect(d[1].data).to.eql([{ x: 0, y: 3 }, { x: 1, y: 7 }]);
       });
     });
 

--- a/test/spec/charts/Status.js
+++ b/test/spec/charts/Status.js
@@ -13,7 +13,7 @@
     describe('The Status chart', () => {
       it('should filter out zero values from data', function () {
         chart.setData({ 'Done': 10, 'Todo': 0, 'In-Progress': 5 });
-        let d = chart.getData();
+        const d = chart.getData();
         expect(d.length).to.eql(2);
         expect(d[0].label).to.eql('Done');
         expect(d[1].label).to.eql('In-Progress');
@@ -22,13 +22,11 @@
         chart.setData({ 'Done': 10, 'In-Progress': 5 });
         expect(() => chart.render()).to.not.throw();
       });
-      it('should set color to a progress array', function () {
-        let result = chart.conf.colors;
-        expect(result).to.eql(['#e46c0a', '#376092', '#77933c', '#c0504d']);
+      it('should use progress colors', function () {
+        expect(chart.getColors()).to.eql(chart.clr.progress());
       });
       it('should have an mLabel of Cat', function () {
-        let result = chart.mLabel;
-        expect(result).to.eql('Cat');
+        expect(chart.mLabel).to.eql('Cat');
       });
     });
 

--- a/test/spec/charts/Timelines.js
+++ b/test/spec/charts/Timelines.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Timelines('charts');
     });
     afterEach(() => {
@@ -22,75 +22,34 @@
         chart.setData([{ label: 'A', status: 'done', days: 10, start: 0 }]);
         expect(() => chart.render()).to.not.throw();
       });
-      it('should provide the correct config', function () {
-        expect(chart.conf.timeline).to.eql({
-          barWidth: .95,
-          show:true,
-        });
-        expect(chart.conf.markers).to.eql({
-          show: true,
-          position: 'rm',
-          fontSize: 9,
-          stacked: true,
-          stackingType: 'a',
-          color: '#545454'
-        });
-        expect(chart.conf.xaxis).to.eql({
-          title: 'Sprint',
-          noTicks: 10,
-          tickDecimals: 0
-        });
-        expect(chart.conf.yaxis).to.eql({
-          showLabels : false
-        });
-        expect(chart.conf.grid).to.eql({
-          horizontalLines : false,
-          color: '#545454',
-          tickColor: '#545454'
-        });
+      it('should use horizontal bar chart', function () {
+        expect(chart.conf.type).to.eql('bar');
+        expect(chart.conf.options.indexAxis).to.eql('y');
       });
-      it('should provide text the labelFormatter method', function () {
-        chart.setData([{
-            'label': 'Theme group 1',
-            'status': 'inprogress',
-            'days': 30,
-            'start': 0
-          },{
-            'label': 'Theme group 2',
-            'status': 'todo',
-            'days': 20,
-            'start': 30
-          }]);
-        let d = chart.labelFormatter({
-          'y': 1
-        });
-        expect(d).to.eql('Theme group 2');
+      it('should set bar labels on conf.data from setData', function () {
+        chart.setData([
+          { label: 'Theme group 1', status: 'inprogress', days: 30, start: 0  },
+          { label: 'Theme group 2', status: 'todo',       days: 20, start: 30 }
+        ]);
+        expect(chart.conf.data.labels[1]).to.eql('Theme group 2');
       });
-      it('should provide text the intervalFormatter method', function () {
+      it('should provide text from the intervalFormatter method', function () {
         chart.setLabels(['Sprint 0', 'Sprint 1'])
-        let d = chart.intervalFormatter(1);
-        expect(d).to.eql('Sprint 1');
+        expect(chart.intervalFormatter(1)).to.eql('Sprint 1');
       });
       it('should have the correct data', function () {
-        chart.setData([{
-            'label': 'Theme group 1',
-            'status': 'inprogress',
-            'days': 30,
-            'start': 0
-          },{
-            'label': 'Theme group 2',
-            'status': 'todo',
-            'days': 20,
-            'start': 30
-          }]);
-        let d = chart.getData();
-        expect(d).to.eql([{
-          'color': '#e46c0a',
-          'data': [[0,0,3]]
-        },{
-          'color': '#376092',
-          'data': [[3,1,2]]
-        }]);
+        chart.setData([
+          { label: 'Theme group 1', status: 'inprogress', days: 30, start: 0  },
+          { label: 'Theme group 2', status: 'todo',       days: 20, start: 30 }
+        ]);
+        const d = chart.getData();
+        expect(d.length).to.eql(2);
+        expect(d[0].label).to.eql('Theme group 1');
+        expect(d[0].start).to.eql(0);
+        expect(d[0].end).to.eql(3);
+        expect(d[1].label).to.eql('Theme group 2');
+        expect(d[1].start).to.eql(3);
+        expect(d[1].end).to.eql(5);
       });
     });
 

--- a/test/spec/charts/TwoBars.js
+++ b/test/spec/charts/TwoBars.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new TwoBars('charts', 'Points');
     });
     afterEach(() => {
@@ -11,67 +11,40 @@
     });
 
     describe('The TwoBars chart', () => {
-      it('should format data', function () {
-        let data = [{
-            label: 'Completed',
-            data: [
-              [-1,2],
-              [1,3],
-              [3,4],
-              [5,5]
-            ]
-          },{
-            label: 'Commited',
-            data: [
-              [0,5],
-              [2,2],
-              [4,7],
-              [6,5]
-            ]
-        }];
+      it('should format data as flat arrays per series', function () {
+        const data = [
+          { label: 'Commited',  data: [5, 10, 15] },
+          { label: 'Completed', data: [3,  8, 12] }
+        ];
         chart.setData(data);
-        expect(chart.getData()[0].label).to.eql('Completed');
-        expect(chart.getData()[1].label).to.eql('Commited');
-        expect(chart.getData()[0].data).to.eql([
-          [-1,[-1,2]],
-          [1,[1,3]],
-          [3,[3,4]],
-          [5,[5,5]]
-        ]);
-        expect(chart.getData()[1].data).to.eql([
-          [0,[0,5]],
-          [2,[2,2]],
-          [4,[4,7]],
-          [6,[6,5]]
-        ]);
+        expect(chart.getData()[0].label).to.eql('Commited');
+        expect(chart.getData()[0].data).to.eql([5, 10, 15]);
+        expect(chart.getData()[1].label).to.eql('Completed');
+        expect(chart.getData()[1].data).to.eql([3, 8, 12]);
       });
-      it('should map adjacent x values to the same sprint label', function () {
+      it('should format label by sprint index', function () {
         chart.setLabels(['Sprint 1', 'Sprint 2', 'Sprint 3']);
-        expect(chart.tickFormatLabels(-1)).to.eql('Sprint 1');
         expect(chart.tickFormatLabels(0)).to.eql('Sprint 1');
         expect(chart.tickFormatLabels(1)).to.eql('Sprint 2');
-        expect(chart.tickFormatLabels(2)).to.eql('Sprint 2');
-        expect(chart.tickFormatLabels(3)).to.eql('Sprint 3');
+        expect(chart.tickFormatLabels(2)).to.eql('Sprint 3');
       });
-      it('should return raw sprint index when no labels are set', function () {
+      it('should return raw value when no labels are set', function () {
         expect(chart.tickFormatLabels(0)).to.eql(0);
         expect(chart.tickFormatLabels(1)).to.eql(1);
       });
       it('should render without throwing', function () {
         chart.setData([
-          { label: 'Commited', data: [[0, 5]] },
-          { label: 'Completed', data: [[1, 3]] }
+          { label: 'Commited',  data: [5] },
+          { label: 'Completed', data: [3] }
         ]);
         expect(() => chart.render()).to.not.throw();
       });
       it('should have a tooltip', function () {
         chart.setLabels(['Sprint 1']);
         expect(chart.tooltip({
-          index: 0,
-          series: {
-            label: 'bob'
-          },
-          y: 10
+          dataIndex: 0,
+          dataset: { label: 'bob' },
+          parsed: { y: 10 }
         })).to.eql('bob 10 points for Sprint 1');
       });
     });

--- a/test/spec/charts/Types.js
+++ b/test/spec/charts/Types.js
@@ -3,7 +3,7 @@
 
   let chart;
     beforeEach(() => {
-      $('#sandbox').append('<p id="charts" style="height:100px;"></p>');
+      $('#sandbox').append('<div id="charts" style="height:100px;"></div>');
       chart = new Types('charts', 'Cat');
     });
     afterEach(() => {
@@ -13,7 +13,7 @@
     describe('The Types chart', () => {
       it('should filter out zero values from data', function () {
         chart.setData({ 'Stories': 5, 'Bugs': 0, 'Spikes': 3 });
-        let d = chart.getData();
+        const d = chart.getData();
         expect(d.length).to.eql(2);
         expect(d[0].label).to.eql('Stories');
         expect(d[1].label).to.eql('Spikes');
@@ -23,8 +23,7 @@
         expect(() => chart.render()).to.not.throw();
       });
       it('should have an mLabel of Cat', function () {
-        let result = chart.mLabel;
-        expect(result).to.eql('Cat');
+        expect(chart.mLabel).to.eql('Cat');
       });
     });
 


### PR DESCRIPTION
## Summary

- Migrates all 9 chart classes from the unmaintained flotr2 (Bower-only, ~2013, canvas-stub required in tests) to Chart.js 4.x (npm UMD bundle, actively maintained, responsive by default)
- Drops the `Flotr` global stub from the node test runner; adds a minimal `Chart` stub
- Removes `flotr2` from `bower.json`; adds `chart.js` to npm `dependencies`
- Adds `/node_modules` BrowserSync route to `serve` and `serve:test` tasks so the UMD bundle is served in dev/test

## Chart type mapping

| Class | flotr2 | Chart.js |
|---|---|---|
| `Burndown`, `Line`, `Lines` | line | `type: 'line'` |
| `TwoBars` | bars (interleaved hack) | `type: 'bar'` native grouping |
| `Pie`, `Status`, `Types` | pie | `type: 'pie'` |
| `Satisfaction` | points (scatter) | `type: 'scatter'` |
| `Timelines` | timeline plugin | `type: 'bar'` + `indexAxis: 'y'` floating bars |

## Notable changes

- **Data format**: flat `[y1, y2, …]` arrays replace flotr2's `[[x, y], …]` pairs; `data.labels` drives the x-axis for categorical charts
- **Tooltips**: `tooltip.callbacks.label` replaces per-dataset `trackFormatter`
- **Notes click**: `options.onClick` on the chart config replaces `Flotr.EventAdapter.observe`
- **Canvas creation**: `Charts` constructor creates a `<canvas>` inside the container `<div>` — no template changes required
- **Status/Types colors**: `getColors()` override replaces `conf.colors` mutation
- All chart specs rewritten to test Chart.js-compatible behaviour; flotr2 internals (`makeDataLine`, `conf.pie`, interleaved bar format, etc.) removed

## Test plan

- [x] `node test/node-runner.js` — 128/128 passing
- [ ] `npx gulp serve` + load with `?team=&project=` — verify all charts render
- [ ] `npx gulp serve:test` + browser suite

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)