### PR TITLE
chore: add .claudeignore and trim human-only commands from CLAUDE.md

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,3 @@
+screenshots/
+dist/
+server/data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,6 @@ cd server && npm run dev
 # Dev server with live reload at http://localhost:9000
 npm run dev
 
-# Dev server exposed on the local network (for phone/tablet access)
-npm run dev:host
-
 # Lint all source files
 npm run lint
 
@@ -41,15 +38,8 @@ npm run test:visual
 npm run dev &
 npm run test:visual:update   # overwrites screenshots/baseline/*.png — commit the results
 
-# Take a screenshot (opens Chrome with DevTools; optional URL argument)
-npm run screenshot
-npm run screenshot -- "http://localhost:9000?team=abc&project=sample"
-
 # Production build → dist/
 npm run build
-
-# Preview production build
-npm run preview
 ```
 
 To load data in the dev server, add query params: `http://localhost:9000?team=abc&project=sample`

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -32,6 +32,12 @@ http://localhost:9000?team=abc&project=sample
 
 The server watches source files and hot-reloads on changes.
 
+To expose the server on your local network (for phone/tablet access):
+
+```bash
+npm run dev:host
+```
+
 ### Claude Code
 
 Prefix the command with `!` so the output appears directly in the conversation:


### PR DESCRIPTION
## Summary

- **`.claudeignore`** — excludes `screenshots/`, `dist/`, and `server/data/` from Claude's context; prevents accidental reads of large binary PNGs and generated files
- **`CLAUDE.md`** — removes `dev:host`, `screenshot`, and `preview` (human-only commands Claude never needs)
- **`CONTRIBUTIONS.md`** — adds `dev:host` alongside the existing `screenshot` and `preview` entries so nothing is lost for humans

🤖 Generated with [Claude Code](https://claude.com/claude-code)