### PR TITLE
feat: add CSV import for board cards and into editor (Phase 0, #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The update release does not include a `teams/` folder.
 
 Copy the **contents** of the uncompressed folder — do not copy over the folder itself or you will overwrite the `teams/` directory and lose your data.
 
+A standalone **JSON Editor** (app/editor.html) is included to create/edit `dashboard.json` / `project.json` / `intervals.json` via forms with live preview and per-section Copy buttons (no more hand-editing). In dev: `/editor.html?team=abc&project=sample`. See the roadmap for Phase 0 details.
+
 ---
 
 ## Getting Started

--- a/app/editor.html
+++ b/app/editor.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>JSON Editor — ScrumChartBoard</title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+<script>try{const p=JSON.parse(localStorage.getItem('scrum_theme_0001')||'{}');document.body.className=`theme-${p.theme||'light'} palette-${p.palette||'forest'}`;}catch(e){document.body.className='theme-light palette-forest';}</script>
+
+<div class="shell editor-wrap">
+  <div class="editor-header">
+    <div>
+      <a href="index.html" class="brand" style="text-decoration:none; display:inline-flex; align-items:center; gap:8px;">
+        <span class="brand-mark"><i></i><i></i><i></i><i></i></span>
+        <strong>Scrum<em>ChartBoard</em></strong>
+      </a>
+      <span style="margin-left:12px; color:var(--text-muted);">JSON Editor</span>
+    </div>
+    <div style="font-size:0.8rem; color:var(--text-muted);">Standalone tool — copy JSON into your <code>teams/</code> files</div>
+  </div>
+
+  <!-- Top controls -->
+  <div class="editor-controls">
+    <label style="font-size:0.75rem; color:var(--text-muted);">Team</label>
+    <input id="team-input" type="text" placeholder="abc" value="abc">
+    <label style="font-size:0.75rem; color:var(--text-muted);">Project</label>
+    <input id="project-input" type="text" placeholder="sample" value="sample">
+    <button id="load-btn" class="button button-primary">Load</button>
+    <span id="load-status" style="margin-left:8px; font-size:0.75rem; color:var(--text-muted);"></span>
+  </div>
+
+  <div class="row">
+    <!-- Left: forms -->
+    <div class="seven columns">
+      <div class="editor-tabs">
+        <button class="editor-tab-btn is-active" data-tab="dashboard">Dashboard</button>
+        <button class="editor-tab-btn" data-tab="project">Project</button>
+        <button class="editor-tab-btn" data-tab="intervals">Intervals</button>
+      </div>
+
+      <!-- Dashboard tab -->
+      <div id="pane-dashboard" class="editor-pane is-active" data-section="dashboard">
+        <div class="editor-form">
+          <label>dashboardName</label>
+          <input id="d-dashboardName" type="text">
+          <label>teamName</label>
+          <input id="d-teamName" type="text">
+          <label>updatedName (optional)</label>
+          <input id="d-updatedName" type="text">
+          <label>daysInInterval</label>
+          <input id="d-daysInInterval" type="number" min="1" value="10">
+        </div>
+        <button class="button editor-copy-btn" data-copy="dashboard">Copy Dashboard JSON</button>
+      </div>
+
+      <!-- Project tab -->
+      <div id="pane-project" class="editor-pane" data-section="project">
+        <div class="editor-form">
+          <label>project.name</label>
+          <input id="p-name" type="text">
+          <label>cardTypeLabel (optional)</label>
+          <input id="p-cardTypeLabel" type="text" placeholder="Points">
+          <div class="repeat-section">
+            <label>cardTypes</label>
+            <div id="p-cardTypes-container"></div>
+            <button type="button" class="button add-btn" data-add="p-cardTypes">+ Add Type</button>
+          </div>
+          <label>cardStatusLabel (optional)</label>
+          <input id="p-cardStatusLabel" type="text" placeholder="Cards">
+          <div class="repeat-section">
+            <label>cardStatus</label>
+            <div id="p-cardStatus-container"></div>
+            <button type="button" class="button add-btn" data-add="p-cardStatus">+ Add Status</button>
+          </div>
+          <label>backlog URL (optional)</label>
+          <input id="p-backlog" type="text" placeholder="https://...">
+        </div>
+
+        <div class="repeat-section">
+          <label>timelines (optional)</label>
+          <div id="p-timelines-container"></div>
+          <button type="button" class="button add-btn" data-add="p-timelines">+ Add Timeline</button>
+        </div>
+
+        <button class="button editor-copy-btn" data-copy="project">Copy Project JSON</button>
+      </div>
+
+      <!-- Intervals tab -->
+      <div id="pane-intervals" class="editor-pane" data-section="intervals">
+        <div id="intervals-container"></div>
+        <button type="button" class="button add-btn" data-add="interval">+ Add Sprint / Interval</button>
+        <div style="margin-top:8px;">
+          <button class="button editor-copy-btn" data-copy="intervals">Copy Intervals JSON</button>
+        </div>
+        <p class="editor-note">Intervals sorted oldest → newest in UI (order in array is preserved on copy).</p>
+      </div>
+    </div>
+
+    <!-- Right: live preview -->
+    <div class="five columns">
+      <div class="editor-preview">
+        <div class="preview-label">
+          <span id="preview-label">Preview</span>
+          <button id="copy-preview-btn" class="button editor-copy-btn">Copy</button>
+        </div>
+        <pre id="preview-json">{}</pre>
+        <p class="editor-note">Preview updates live. Use the tab-specific Copy buttons (or this one) and paste into the matching .json file.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="module" src="/scripts/editor.js"></script>
+</body>
+</html>

--- a/app/editor.html
+++ b/app/editor.html
@@ -66,6 +66,7 @@
             <label>cardTypes</label>
             <div id="p-cardTypes-container"></div>
             <button type="button" class="button add-btn" data-add="p-cardTypes">+ Add Type</button>
+            <button type="button" class="button add-btn" data-import-csv="p-cardTypes">Import CSV</button>
           </div>
           <label>cardStatusLabel (optional)</label>
           <input id="p-cardStatusLabel" type="text" placeholder="Cards">
@@ -73,6 +74,7 @@
             <label>cardStatus</label>
             <div id="p-cardStatus-container"></div>
             <button type="button" class="button add-btn" data-add="p-cardStatus">+ Add Status</button>
+            <button type="button" class="button add-btn" data-import-csv="p-cardStatus">Import CSV</button>
           </div>
           <label>backlog URL (optional)</label>
           <input id="p-backlog" type="text" placeholder="https://...">

--- a/app/scripts/Board.js
+++ b/app/scripts/Board.js
@@ -10,11 +10,13 @@ export default class Board {
     this._store = store;
     this._backlogLimit = PAGE;
     this._sortables = [];
+    this._lastContainerId = null;
   }
 
   render(containerId) {
     const el = document.getElementById(containerId);
     if (!el) return;
+    this._lastContainerId = containerId;
     el.innerHTML = this._html();
     this._bind(el);
     this._initSortable(el);
@@ -34,6 +36,7 @@ export default class Board {
       <div class="board-col-header">
         <span class="board-col-title">${LABELS[status]}</span>
         <span class="board-col-count">${all.length}</span>
+        ${status === 'backlog' ? '<button class="board-import-btn" title="Import cards from CSV (columns: title,type,points,blocked)">Import CSV</button>' : ''}
       </div>
       ${status === 'backlog' ? this._formHtml() : ''}
       <div class="board-col-cards" data-status="${status}">
@@ -112,6 +115,11 @@ export default class Board {
         this.render(el.id);
       });
     });
+
+    const importBtn = el.querySelector('.board-import-btn');
+    if (importBtn) {
+      importBtn.addEventListener('click', () => this._importCSV());
+    }
   }
 
   _initSortable(el) {
@@ -135,5 +143,84 @@ export default class Board {
         }
       }));
     });
+  }
+
+  _parseCSV(text) {
+    if (!text) return [];
+    const lines = text.replace(/\r/g, '').trim().split('\n');
+    if (lines.length < 2) return [];
+    const headerLine = lines[0];
+    const headers = this._splitCSVLine(headerLine).map(h => h.toLowerCase().trim());
+    const result = [];
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      const values = this._splitCSVLine(line);
+      const row = {};
+      headers.forEach((h, j) => { row[h] = (values[j] || '').trim(); });
+      result.push(row);
+    }
+    return result;
+  }
+
+  _splitCSVLine(line) {
+    const result = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
+      if (char === '"') {
+        inQuotes = !inQuotes;
+      } else if (char === ',' && !inQuotes) {
+        result.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    result.push(current);
+    return result.map(v => v.replace(/^"|"$/g, '').trim());
+  }
+
+  _importCSV() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.csv,text/csv';
+    input.style.display = 'none';
+    document.body.appendChild(input);
+    input.onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) {
+        document.body.removeChild(input);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const text = ev.target.result;
+        const rows = this._parseCSV(text);
+        let added = 0;
+        rows.forEach(r => {
+          const title = (r.title || r['card title'] || r.name || '').trim();
+          if (!title) return;
+          const type = r.type || r['card type'] || 'Story';
+          let points = parseInt(r.points || r.pts || r.effort || '0', 10);
+          if (isNaN(points)) points = 0;
+          const blockedStr = (r.blocked || r['is blocked'] || '').toLowerCase();
+          const blocked = blockedStr === 'true' || blockedStr === 'yes' || blockedStr === '1';
+          this._store.addCard({ title, type, points, blocked });
+          added++;
+        });
+        document.body.removeChild(input);
+        if (added > 0) {
+          const backlogCount = this._store.getCards().filter(c => c.status === 'backlog').length;
+          if (backlogCount > this._backlogLimit) this._backlogLimit = backlogCount;
+          if (this._lastContainerId) {
+            this.render(this._lastContainerId);
+          }
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
   }
 }

--- a/app/scripts/BoardAdapter.js
+++ b/app/scripts/BoardAdapter.js
@@ -1,0 +1,216 @@
+/**
+ * BoardAdapter
+ * Transforms data from Store (cards, planning intervals, timelines)
+ * into the shape expected by Model / dashboard charts.
+ *
+ * This allows the interactive Board/Planner/Timeline to drive
+ * the rich charts (status, types, timelines, basic committed/completed,
+ * estimated cards, etc.) without requiring manual JSON edits for those parts.
+ *
+ * Historical/full metrics (satisfaction, exact capacity, past velocity)
+ * still benefit from the editor + intervals.json, but current board state
+ * will populate/override dynamic parts.
+ *
+ * Usage:
+ *   import BoardAdapter from './BoardAdapter.js';
+ *   const storeData = {
+ *     cards: store.getCards(),
+ *     intervals: store.getIntervals(),
+ *     timelines: store.getTimelines()
+ *   };
+ *   const finalData = BoardAdapter.toDashboardData(storeData, baseFromJson);
+ *   const model = new Model(finalData);
+ */
+export default class BoardAdapter {
+  /**
+   * @param {object} storeData - { cards: [], intervals: [], timelines: [] } from Store
+   * @param {object} baseData - optional base from dashboard.json + project + intervals (from GetData)
+   * @returns {object} data suitable for new Model(data)
+   */
+  static toDashboardData(storeData = {}, baseData = {}) {
+    const { cards = [], intervals: boardIntervals = [], timelines: boardTimelines = [] } = storeData;
+
+    // Start from base (legacy JSONs for historical + config) or sensible defaults
+    const data = JSON.parse(JSON.stringify(baseData || {})); // shallow clone for safety
+
+    // Ensure top-level structure
+    if (!data.project) data.project = {};
+    if (!data.intervals) data.intervals = [];
+    if (!data.dashboardName) data.dashboardName = data.dashboardName || 'Board-Driven Dashboard';
+    if (!data.teamName) data.teamName = data.teamName || 'Team';
+    if (!data.daysInInterval) data.daysInInterval = data.daysInInterval || 10;
+
+    // 1. Derive current project status and types purely from board cards (live!)
+    const statusCounts = {
+      'In-Progress': 0,
+      'Done': 0,
+      'Todo': 0,
+      'Blocked': 0
+    };
+    const typeCounts = {};
+    let totalEstimated = 0;
+    let totalUnestimated = 0;
+
+    cards.forEach(card => {
+      const status = card.status || 'backlog';
+      if (status === 'inprogress') statusCounts['In-Progress']++;
+      else if (status === 'done') statusCounts['Done']++;
+      else if (status === 'todo' || status === 'backlog') statusCounts['Todo']++;
+      if (card.blocked) statusCounts['Blocked']++;
+
+      const t = card.type || 'Story';
+      typeCounts[t] = (typeCounts[t] || 0) + 1;
+
+      if (card.points && card.points > 0) totalEstimated++;
+      else totalUnestimated++;
+    });
+
+    data.project.cardStatus = statusCounts;
+    data.project.cardStatusLabel = data.project.cardStatusLabel || 'Cards';
+    data.project.cardTypes = typeCounts;
+    data.project.cardTypeLabel = data.project.cardTypeLabel || 'Points';
+
+    // 2. Timelines live from board store (override base)
+    if (boardTimelines && boardTimelines.length > 0) {
+      data.project.timelines = boardTimelines.map(t => ({
+        title: t.name || t.title || 'Untitled Timeline',
+        timeline: (t.timeline || []).map(item => ({
+          label: item.label || '',
+          status: item.status || 'todo',
+          days: Number(item.days) || 0,
+          start: Number(item.start) || 0
+        }))
+      }));
+    }
+
+    // 3. Intervals: use board planning intervals to drive per-interval charts
+    //    Derive committed/completed/estimated from cards assigned to each intervalId.
+    //    Fall back to base intervals for historical context if present.
+    //    This is the key to "board data drives charts".
+    if (boardIntervals && boardIntervals.length > 0) {
+      const derivedIntervals = boardIntervals.map((bi, index) => {
+        const intervalId = bi.id;
+        const assignedCards = cards.filter(c => c.intervalId === intervalId);
+        const doneCards = assignedCards.filter(c => c.status === 'done');
+        const committedPoints = assignedCards.reduce((sum, c) => sum + (Number(c.points) || 0), 0);
+        const completedPoints = doneCards.reduce((sum, c) => sum + (Number(c.points) || 0), 0);
+        const estimatedCards = assignedCards.filter(c => Number(c.points) > 0).length;
+        const unestimatedCards = assignedCards.filter(c => !c.points || Number(c.points) === 0).length;
+        const blockedCards = assignedCards.filter(c => c.blocked).length;
+
+        // Use base interval if exists for label/dates/team size, else derive
+        const baseInterval = (data.intervals || []).find(i => (i.label || '').toLowerCase().includes((bi.name || bi.label || '').toLowerCase())) || data.intervals[index] || {};
+
+        return {
+          label: bi.name || bi.label || `Interval ${index + 1}`,
+          review: baseInterval.review || '',
+          dateStart: bi.startDate || baseInterval.dateStart || '',
+          dateEnd: bi.endDate || baseInterval.dateEnd || '',
+          teamMembersCount: baseInterval.teamMembersCount || 5,
+          satisfactionTeam: baseInterval.satisfactionTeam || [],
+          satisfactionShareholders: baseInterval.satisfactionShareholders || [],
+          pointsCommited: committedPoints,
+          pointsCompleted: completedPoints,
+          pointsEstimated: Math.max(committedPoints * 1.5, baseInterval.pointsEstimated || 50),
+          cardsCommited: assignedCards.length,
+          cardsCompleted: doneCards.length,
+          cardsEstimated: estimatedCards,
+          cardsUnestimated: unestimatedCards,
+          cardsBlocked: blockedCards,
+          daysTimebox: baseInterval.daysTimebox || [0],
+          daysOutHolidays: baseInterval.daysOutHolidays || 0,
+          daysOutPlanned: baseInterval.daysOutPlanned || [0],
+          daysOutUnplanned: baseInterval.daysOutUnplanned || [0],
+          issuesPerInterval: baseInterval.issuesPerInterval || 0,
+          notesInterval: baseInterval.notesInterval || ''
+        };
+      });
+
+      // If we have base historical intervals, keep them + append/override with derived current ones.
+      // For simplicity in Phase 0: prefer derived if board intervals exist (user is actively planning)
+      data.intervals = derivedIntervals;
+    }
+
+    // 4. Ensure other dashboard fields
+    if (!data.updatedName && baseData.updatedName) data.updatedName = baseData.updatedName;
+    if (!data.updatedDate && baseData.updatedDate) data.updatedDate = baseData.updatedDate;
+
+    // Cards summary for the "Cards" stat (estimated %)
+    // Model uses per-interval, but we set a synthetic last interval or rely on derived above.
+    // The derived intervals already carry cardsEstimated / Unestimated.
+
+    return data;
+  }
+
+  /**
+   * Optional helper: export current board state back to the 3-JSON shape
+   * (useful for "snapshot" button in future or editor integration).
+   */
+  static toJsonFiles(storeData = {}) {
+    const { cards = [], intervals: boardIntervals = [], timelines: boardTimelines = [] } = storeData;
+
+    // dashboard.json stub
+    const dashboard = {
+      dashboardName: 'Board Project',
+      teamName: 'Team',
+      daysInInterval: 10
+    };
+
+    // project.json from current cards + timelines
+    const statusCounts = { 'In-Progress': 0, Done: 0, Todo: 0, Blocked: 0 };
+    const typeCounts = {};
+    cards.forEach(c => {
+      const s = c.status === 'inprogress' ? 'In-Progress' : c.status === 'done' ? 'Done' : c.status === 'todo' ? 'Todo' : 'Todo';
+      statusCounts[s] = (statusCounts[s] || 0) + 1;
+      if (c.blocked) statusCounts.Blocked = (statusCounts.Blocked || 0) + 1;
+      const t = c.type || 'Story';
+      typeCounts[t] = (typeCounts[t] || 0) + 1;
+    });
+
+    const project = {
+      name: 'Board Project',
+      cardTypeLabel: 'Points',
+      cardTypes: typeCounts,
+      cardStatusLabel: 'Cards',
+      cardStatus: statusCounts,
+      timelines: boardTimelines.map(t => ({
+        title: t.name || t.title || 'Timeline',
+        timeline: (t.timeline || []).map(it => ({
+          label: it.label || '',
+          status: it.status || 'todo',
+          days: Number(it.days) || 0,
+          start: Number(it.start) || 0
+        }))
+      }))
+    };
+
+    // intervals.json stub derived from board planning intervals + card aggregates
+    const intervals = boardIntervals.map((bi, i) => {
+      const assigned = cards.filter(c => c.intervalId === bi.id);
+      const done = assigned.filter(c => c.status === 'done');
+      return {
+        label: bi.name || bi.label || `Interval ${i+1}`,
+        dateStart: bi.startDate || '',
+        dateEnd: bi.endDate || '',
+        teamMembersCount: 5,
+        satisfactionTeam: [],
+        satisfactionShareholders: [],
+        pointsCommited: assigned.reduce((s, c) => s + (c.points || 0), 0),
+        pointsCompleted: done.reduce((s, c) => s + (c.points || 0), 0),
+        pointsEstimated: 0,
+        cardsCommited: assigned.length,
+        cardsCompleted: done.length,
+        cardsEstimated: assigned.filter(c => c.points > 0).length,
+        cardsUnestimated: assigned.filter(c => !c.points).length,
+        cardsBlocked: assigned.filter(c => c.blocked).length,
+        daysTimebox: [0],
+        daysOutHolidays: 0,
+        daysOutPlanned: [0],
+        daysOutUnplanned: [0],
+        issuesPerInterval: 0
+      };
+    });
+
+    return { dashboard, project: { project }, intervals: { intervals } };
+  }
+}

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -1,0 +1,601 @@
+// editor.js — vanilla JS JSON editor for the three data files (no jQuery)
+// Mirrors the detailed spec from GitHub issue #74.
+
+const state = {
+  team: '',
+  project: '',
+  dashboard: {
+    dashboardName: '',
+    teamName: '',
+    updatedName: '',
+    daysInInterval: 10
+  },
+  projectData: {
+    name: '',
+    cardTypeLabel: '',
+    cardTypes: [],        // [{key, value}]
+    cardStatusLabel: '',
+    cardStatus: [],       // [{key, value}]
+    backlog: '',
+    timelines: []         // [{title, timeline: [{label, status, days, start}]}]
+  },
+  intervals: []           // full interval objects as per DATA_FORMAT (arrays preserved)
+};
+
+let currentTab = 'dashboard';
+
+function $(sel, root = document) { return root.querySelector(sel); }
+function $$(sel, root = document) { return Array.from(root.querySelectorAll(sel)); }
+
+function updatePreview() {
+  const previewEl = $('#preview-json');
+  const labelEl = $('#preview-label');
+  let data;
+  let label = 'Preview';
+
+  if (currentTab === 'dashboard') {
+    data = { ...state.dashboard };
+    label = 'dashboard.json';
+  } else if (currentTab === 'project') {
+    data = {
+      project: {
+        name: state.projectData.name || '',
+        cardTypeLabel: state.projectData.cardTypeLabel || undefined,
+        cardTypes: arrayToObject(state.projectData.cardTypes),
+        cardStatusLabel: state.projectData.cardStatusLabel || undefined,
+        cardStatus: arrayToObject(state.projectData.cardStatus),
+        backlog: state.projectData.backlog || undefined,
+        timelines: state.projectData.timelines.length ? state.projectData.timelines : undefined
+      }
+    };
+    // clean undefined
+    Object.keys(data.project).forEach(k => { if (data.project[k] === undefined) delete data.project[k]; });
+    label = 'project.json';
+  } else if (currentTab === 'intervals') {
+    data = { intervals: state.intervals };
+    label = 'intervals.json';
+  }
+
+  previewEl.textContent = JSON.stringify(data, null, 2);
+  labelEl.textContent = label;
+}
+
+function arrayToObject(arr) {
+  const obj = {};
+  (arr || []).forEach(item => {
+    if (item && item.key) obj[item.key] = Number(item.value) || 0;
+  });
+  return obj;
+}
+
+function objectToArray(obj) {
+  if (!obj || typeof obj !== 'object') return [];
+  return Object.keys(obj).map(k => ({ key: k, value: obj[k] }));
+}
+
+function bindInput(id, path) {
+  const el = $(`#${id}`);
+  if (!el) return;
+  el.addEventListener('input', () => {
+    const val = el.type === 'number' ? (el.value === '' ? 0 : Number(el.value)) : el.value;
+    setPath(state, path, val);
+    updatePreview();
+  });
+}
+
+function setPath(obj, path, val) {
+  const parts = path.split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!cur[parts[i]]) cur[parts[i]] = {};
+    cur = cur[parts[i]];
+  }
+  cur[parts[parts.length-1]] = val;
+}
+
+function getPath(obj, path) {
+  return path.split('.').reduce((o, k) => (o ? o[k] : undefined), obj);
+}
+
+// --- Repeating helpers ---
+
+function renderKeyValueRepeat(containerId, arrPath, label = 'Item') {
+  const container = $(`#${containerId}`);
+  if (!container) return;
+  container.innerHTML = '';
+  const arr = getPath(state, arrPath) || [];
+  arr.forEach((item, idx) => {
+    const row = document.createElement('div');
+    row.className = 'repeat-row';
+    row.innerHTML = `
+      <input type="text" placeholder="key" value="${item.key || ''}" data-idx="${idx}">
+      <input type="number" placeholder="value" value="${item.value || 0}" data-idx="${idx}">
+      <button type="button" class="remove-btn" data-idx="${idx}" title="Remove">×</button>
+    `;
+    const [keyIn, valIn] = row.querySelectorAll('input');
+    keyIn.addEventListener('input', () => {
+      arr[idx].key = keyIn.value;
+      updatePreview();
+    });
+    valIn.addEventListener('input', () => {
+      arr[idx].value = valIn.value === '' ? 0 : Number(valIn.value);
+      updatePreview();
+    });
+    row.querySelector('.remove-btn').addEventListener('click', () => {
+      arr.splice(idx, 1);
+      renderKeyValueRepeat(containerId, arrPath);
+      updatePreview();
+    });
+    container.appendChild(row);
+  });
+}
+
+function addKeyValueRepeat(containerId, arrPath) {
+  const arr = getPath(state, arrPath);
+  if (!Array.isArray(arr)) return;
+  arr.push({ key: '', value: 0 });
+  renderKeyValueRepeat(containerId, arrPath);
+  updatePreview();
+}
+
+function renderNumberRepeat(containerId, arrPath) {
+  const container = $(`#${containerId}`);
+  if (!container) return;
+  container.innerHTML = '';
+  const arr = getPath(state, arrPath) || [];
+  arr.forEach((num, idx) => {
+    const row = document.createElement('div');
+    row.className = 'repeat-row';
+    row.innerHTML = `
+      <input type="number" value="${num != null ? num : ''}" data-idx="${idx}">
+      <button type="button" class="remove-btn" data-idx="${idx}" title="Remove">×</button>
+    `;
+    const input = row.querySelector('input');
+    input.addEventListener('input', () => {
+      arr[idx] = input.value === '' ? 0 : Number(input.value);
+      updatePreview();
+    });
+    row.querySelector('.remove-btn').addEventListener('click', () => {
+      arr.splice(idx, 1);
+      renderNumberRepeat(containerId, arrPath);
+      updatePreview();
+    });
+    container.appendChild(row);
+  });
+}
+
+function addNumberRepeat(containerId, arrPath) {
+  const arr = getPath(state, arrPath);
+  if (!Array.isArray(arr)) return;
+  arr.push(0);
+  renderNumberRepeat(containerId, arrPath);
+  updatePreview();
+}
+
+// --- Timelines (nested) ---
+
+function renderTimelines() {
+  const container = $('#p-timelines-container');
+  if (!container) return;
+  container.innerHTML = '';
+  state.projectData.timelines.forEach((tl, tIdx) => {
+    const block = document.createElement('div');
+    block.className = 'collapsible';
+    block.innerHTML = `
+      <details open>
+        <summary>
+          Timeline ${tIdx + 1}: <input type="text" value="${tl.title || ''}" style="width:180px; display:inline;" data-tidx="${tIdx}">
+          <button type="button" class="remove-btn" data-tidx="${tIdx}" style="float:right;">×</button>
+        </summary>
+        <div class="collapsible-body">
+          <div data-timeline-items="${tIdx}"></div>
+          <button type="button" class="button add-btn" data-add-timeline-item="${tIdx}">+ Add Theme</button>
+        </div>
+      </details>
+    `;
+    const titleIn = block.querySelector('input');
+    titleIn.addEventListener('input', () => {
+      state.projectData.timelines[tIdx].title = titleIn.value;
+      updatePreview();
+    });
+    block.querySelector('.remove-btn').addEventListener('click', (e) => {
+      e.preventDefault();
+      state.projectData.timelines.splice(tIdx, 1);
+      renderTimelines();
+      updatePreview();
+    });
+    container.appendChild(block);
+    renderTimelineItems(tIdx, block.querySelector(`[data-timeline-items="${tIdx}"]`));
+    block.querySelector(`[data-add-timeline-item="${tIdx}"]`).addEventListener('click', () => {
+      if (!state.projectData.timelines[tIdx].timeline) state.projectData.timelines[tIdx].timeline = [];
+      state.projectData.timelines[tIdx].timeline.push({ label: '', status: 'todo', days: 0, start: 0 });
+      renderTimelines();
+      updatePreview();
+    });
+  });
+}
+
+function renderTimelineItems(tIdx, container) {
+  container.innerHTML = '';
+  const items = state.projectData.timelines[tIdx].timeline || [];
+  items.forEach((item, iIdx) => {
+    const row = document.createElement('div');
+    row.className = 'repeat-row';
+    row.style.flexWrap = 'wrap';
+    row.innerHTML = `
+      <input type="text" placeholder="label" value="${item.label || ''}" style="flex:2 1 140px;">
+      <select style="flex:1 1 80px;">
+        <option value="todo">todo</option>
+        <option value="inprogress">inprogress</option>
+        <option value="done">done</option>
+      </select>
+      <input type="number" placeholder="days" value="${item.days || 0}" style="width:70px;">
+      <input type="number" placeholder="start" value="${item.start || 0}" style="width:70px;">
+      <button type="button" class="remove-btn" title="Remove">×</button>
+    `;
+    const [labelIn, statusSel, daysIn, startIn] = row.querySelectorAll('input,select');
+    labelIn.addEventListener('input', () => { items[iIdx].label = labelIn.value; updatePreview(); });
+    statusSel.value = item.status || 'todo';
+    statusSel.addEventListener('change', () => { items[iIdx].status = statusSel.value; updatePreview(); });
+    daysIn.addEventListener('input', () => { items[iIdx].days = Number(daysIn.value)||0; updatePreview(); });
+    startIn.addEventListener('input', () => { items[iIdx].start = Number(startIn.value)||0; updatePreview(); });
+    row.querySelector('.remove-btn').addEventListener('click', () => {
+      items.splice(iIdx, 1);
+      renderTimelines();
+      updatePreview();
+    });
+    container.appendChild(row);
+  });
+}
+
+function addTimeline() {
+  state.projectData.timelines.push({ title: '', timeline: [] });
+  renderTimelines();
+  updatePreview();
+}
+
+// --- Intervals (complex) ---
+
+function renderIntervals() {
+  const container = $('#intervals-container');
+  if (!container) return;
+  container.innerHTML = '';
+  state.intervals.forEach((iv, idx) => {
+    const det = document.createElement('div');
+    det.className = 'collapsible';
+    const summaryText = `${iv.label || 'New Interval'} — ${iv.dateStart || ''} to ${iv.dateEnd || ''}`;
+    det.innerHTML = `
+      <details>
+        <summary>
+          ${summaryText}
+          <button type="button" class="remove-btn" data-iidx="${idx}" style="float:right; margin-top:-2px;">×</button>
+        </summary>
+        <div class="collapsible-body" data-iv-body="${idx}">
+          <!-- populated by JS -->
+        </div>
+      </details>
+    `;
+    const removeBtn = det.querySelector('.remove-btn');
+    removeBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      state.intervals.splice(idx, 1);
+      renderIntervals();
+      updatePreview();
+    });
+    container.appendChild(det);
+    renderIntervalBody(idx, det.querySelector(`[data-iv-body="${idx}"]`));
+  });
+}
+
+function renderIntervalBody(idx, body) {
+  body.innerHTML = '';
+  const iv = state.intervals[idx];
+  const fields = [
+    ['label', 'text', 'Label'],
+    ['review', 'text', 'Review URL (opt)'],
+    ['dateStart', 'text', 'dateStart (mm/dd/yyyy)'],
+    ['dateEnd', 'text', 'dateEnd (mm/dd/yyyy)'],
+    ['teamMembersCount', 'number', 'teamMembersCount'],
+    ['pointsCommited', 'number', 'pointsCommited'],
+    ['pointsCompleted', 'number', 'pointsCompleted'],
+    ['pointsEstimated', 'number', 'pointsEstimated'],
+    ['cardsCommited', 'number', 'cardsCommited'],
+    ['cardsCompleted', 'number', 'cardsCompleted'],
+    ['cardsEstimated', 'number', 'cardsEstimated'],
+    ['cardsUnestimated', 'number', 'cardsUnestimated'],
+    ['cardsBlocked', 'number', 'cardsBlocked'],
+    ['daysOutHolidays', 'number', 'daysOutHolidays'],
+    ['issuesPerInterval', 'number', 'issuesPerInterval'],
+    ['notesInterval', 'text', 'notesInterval (opt)']
+  ];
+
+  fields.forEach(([key, type, label]) => {
+    const wrap = document.createElement('div');
+    wrap.innerHTML = `<label style="margin-top:8px;">${label}</label><input data-iv-key="${key}" type="${type}" value="${iv[key] != null ? iv[key] : ''}">`;
+    const input = wrap.querySelector('input');
+    input.addEventListener('input', () => {
+      iv[key] = type === 'number' ? (input.value==='' ? 0 : Number(input.value)) : input.value;
+      updatePreview();
+    });
+    body.appendChild(wrap);
+  });
+
+  // Repeating number arrays
+  const repeats = [
+    ['satisfactionTeam', 'Satisfaction Team (scores)'],
+    ['satisfactionShareholders', 'Satisfaction Shareholders (scores)'],
+    ['daysTimebox', 'Days Timebox'],
+    ['daysOutPlanned', 'Days Out Planned'],
+    ['daysOutUnplanned', 'Days Out Unplanned']
+  ];
+  repeats.forEach(([key, label]) => {
+    if (!Array.isArray(iv[key])) iv[key] = [];
+    const sec = document.createElement('div');
+    sec.className = 'repeat-section';
+    sec.innerHTML = `<label>${label}</label><div data-repeat-iv="${key}-${idx}"></div>`;
+    const add = document.createElement('button');
+    add.type = 'button';
+    add.className = 'button add-btn';
+    add.textContent = '+ Add';
+    add.addEventListener('click', () => {
+      iv[key].push(0);
+      renderNumberRepeatForInterval(sec.querySelector(`[data-repeat-iv="${key}-${idx}"]`), iv[key], idx, key);
+      updatePreview();
+    });
+    sec.appendChild(add);
+    body.appendChild(sec);
+    renderNumberRepeatForInterval(sec.querySelector(`[data-repeat-iv="${key}-${idx}"]`), iv[key], idx, key);
+  });
+}
+
+function renderNumberRepeatForInterval(container, arr, ivIdx, key) {
+  container.innerHTML = '';
+  arr.forEach((val, vIdx) => {
+    const r = document.createElement('div');
+    r.className = 'repeat-row';
+    r.innerHTML = `<input type="number" value="${val != null ? val : ''}"><button type="button" class="remove-btn">×</button>`;
+    const inp = r.querySelector('input');
+    inp.addEventListener('input', () => { arr[vIdx] = inp.value===''?0:Number(inp.value); updatePreview(); });
+    r.querySelector('.remove-btn').addEventListener('click', () => {
+      arr.splice(vIdx, 1);
+      renderNumberRepeatForInterval(container, arr, ivIdx, key);
+      updatePreview();
+    });
+    container.appendChild(r);
+  });
+}
+
+function addInterval() {
+  state.intervals.push({
+    label: 'New Interval',
+    dateStart: '',
+    dateEnd: '',
+    teamMembersCount: 0,
+    satisfactionTeam: [],
+    satisfactionShareholders: [],
+    pointsCommited: 0,
+    pointsCompleted: 0,
+    pointsEstimated: 0,
+    cardsCommited: 0,
+    cardsCompleted: 0,
+    cardsEstimated: 0,
+    cardsUnestimated: 0,
+    cardsBlocked: 0,
+    daysTimebox: [],
+    daysOutHolidays: 0,
+    daysOutPlanned: [],
+    daysOutUnplanned: [],
+    issuesPerInterval: 0,
+    notesInterval: ''
+  });
+  renderIntervals();
+  updatePreview();
+}
+
+// --- Tab handling ---
+
+function switchTab(tab) {
+  currentTab = tab;
+  $$('.editor-tab-btn').forEach(b => b.classList.toggle('is-active', b.dataset.tab === tab));
+  $$('.editor-pane').forEach(p => p.classList.toggle('is-active', p.id === `pane-${tab}`));
+  updatePreview();
+}
+
+function bindTabs() {
+  $$('.editor-tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  });
+}
+
+// --- Load / init ---
+
+async function loadData() {
+  const team = $('#team-input').value.trim();
+  const project = $('#project-input').value.trim();
+  if (!team || !project) {
+    $('#load-status').textContent = 'Team and project required';
+    return;
+  }
+  state.team = team;
+  state.project = project;
+  $('#load-status').textContent = 'Loading...';
+
+  try {
+    const base = `/teams/${encodeURIComponent(team)}/projects/${encodeURIComponent(project)}/`;
+    const [dashRes, projRes, intRes] = await Promise.all([
+      fetch(`/teams/${encodeURIComponent(team)}/dashboard.json`),
+      fetch(base + 'project.json'),
+      fetch(base + 'intervals.json')
+    ]);
+
+    if (!dashRes.ok) throw new Error('dashboard not found');
+    const dash = await dashRes.json();
+
+    state.dashboard = {
+      dashboardName: dash.dashboardName || '',
+      teamName: dash.teamName || '',
+      updatedName: dash.updatedName || '',
+      daysInInterval: dash.daysInInterval || 10
+    };
+
+    let proj = {};
+    if (projRes.ok) {
+      const p = await projRes.json();
+      proj = p.project || {};
+    }
+    state.projectData = {
+      name: proj.name || '',
+      cardTypeLabel: proj.cardTypeLabel || '',
+      cardTypes: objectToArray(proj.cardTypes),
+      cardStatusLabel: proj.cardStatusLabel || '',
+      cardStatus: objectToArray(proj.cardStatus),
+      backlog: proj.backlog || '',
+      timelines: (proj.timelines || []).map(t => ({
+        title: t.title || '',
+        timeline: (t.timeline || []).map(it => ({...it}))
+      }))
+    };
+
+    let ints = [];
+    if (intRes.ok) {
+      const i = await intRes.json();
+      ints = (i.intervals || []).map(iv => ({...iv}));
+    }
+    state.intervals = ints;
+
+    renderAllForms();
+    updatePreview();
+    $('#load-status').textContent = 'Loaded ✓ (copy JSONs to your teams/ folder)';
+  } catch (e) {
+    console.warn(e);
+    // start blank
+    state.dashboard = { dashboardName: '', teamName: '', updatedName: '', daysInInterval: 10 };
+    state.projectData = { name: '', cardTypeLabel: '', cardTypes: [], cardStatusLabel: '', cardStatus: [], backlog: '', timelines: [] };
+    state.intervals = [];
+    renderAllForms();
+    updatePreview();
+    $('#load-status').textContent = 'No data or error — starting blank form';
+  }
+}
+
+function renderAllForms() {
+  // dashboard
+  $('#d-dashboardName').value = state.dashboard.dashboardName || '';
+  $('#d-teamName').value = state.dashboard.teamName || '';
+  $('#d-updatedName').value = state.dashboard.updatedName || '';
+  $('#d-daysInInterval').value = state.dashboard.daysInInterval || 10;
+
+  // project scalars
+  $('#p-name').value = state.projectData.name || '';
+  $('#p-cardTypeLabel').value = state.projectData.cardTypeLabel || '';
+  $('#p-cardStatusLabel').value = state.projectData.cardStatusLabel || '';
+  $('#p-backlog').value = state.projectData.backlog || '';
+
+  // repeats
+  renderKeyValueRepeat('p-cardTypes-container', 'projectData.cardTypes');
+  renderKeyValueRepeat('p-cardStatus-container', 'projectData.cardStatus');
+  renderTimelines();
+
+  // intervals
+  renderIntervals();
+
+  // rebind simple inputs (in case)
+  bindSimpleInputs();
+}
+
+function bindSimpleInputs() {
+  // Dashboard
+  bindInput('d-dashboardName', 'dashboard.dashboardName');
+  bindInput('d-teamName', 'dashboard.teamName');
+  bindInput('d-updatedName', 'dashboard.updatedName');
+  bindInput('d-daysInInterval', 'dashboard.daysInInterval');
+
+  // Project
+  bindInput('p-name', 'projectData.name');
+  bindInput('p-cardTypeLabel', 'projectData.cardTypeLabel');
+  bindInput('p-cardStatusLabel', 'projectData.cardStatusLabel');
+  bindInput('p-backlog', 'projectData.backlog');
+}
+
+function bindAddButtons() {
+  // card types/status
+  document.addEventListener('click', (e) => {
+    if (e.target.matches('[data-add="p-cardTypes"]')) addKeyValueRepeat('p-cardTypes-container', 'projectData.cardTypes');
+    if (e.target.matches('[data-add="p-cardStatus"]')) addKeyValueRepeat('p-cardStatus-container', 'projectData.cardStatus');
+    if (e.target.matches('[data-add="p-timelines"]')) addTimeline();
+    if (e.target.matches('[data-add="interval"]')) addInterval();
+  });
+
+  // copy buttons
+  document.addEventListener('click', (e) => {
+    if (e.target.matches('[data-copy]')) {
+      const section = e.target.getAttribute('data-copy');
+      let toCopy;
+      if (section === 'dashboard') toCopy = { ...state.dashboard };
+      else if (section === 'project') {
+        toCopy = { project: {
+          name: state.projectData.name,
+          cardTypeLabel: state.projectData.cardTypeLabel || undefined,
+          cardTypes: arrayToObject(state.projectData.cardTypes),
+          cardStatusLabel: state.projectData.cardStatusLabel || undefined,
+          cardStatus: arrayToObject(state.projectData.cardStatus),
+          backlog: state.projectData.backlog || undefined,
+          timelines: state.projectData.timelines.length ? state.projectData.timelines : undefined
+        }};
+        Object.keys(toCopy.project).forEach(k => toCopy.project[k]===undefined && delete toCopy.project[k]);
+      } else if (section === 'intervals') {
+        toCopy = { intervals: state.intervals };
+      }
+      navigator.clipboard.writeText(JSON.stringify(toCopy, null, 2)).then(() => {
+        const orig = e.target.textContent;
+        e.target.textContent = 'Copied!';
+        setTimeout(() => e.target.textContent = orig, 1200);
+      });
+    }
+    if (e.target.id === 'copy-preview-btn') {
+      const txt = $('#preview-json').textContent;
+      navigator.clipboard.writeText(txt);
+      const orig = e.target.textContent;
+      e.target.textContent = 'Copied!';
+      setTimeout(() => e.target.textContent = orig, 1200);
+    }
+  });
+}
+
+function initFromQuery() {
+  const params = new URLSearchParams(location.search);
+  const t = params.get('team');
+  const p = params.get('project');
+  if (t) $('#team-input').value = t;
+  if (p) $('#project-input').value = p;
+  if (t && p) {
+    // auto load for convenience
+    setTimeout(() => loadData(), 50);
+  }
+}
+
+function init() {
+  // bind load
+  $('#load-btn').addEventListener('click', loadData);
+
+  bindTabs();
+  bindAddButtons();
+
+  // initial blank forms
+  renderAllForms();
+  bindSimpleInputs();
+  updatePreview();
+
+  initFromQuery();
+
+  // allow Enter in top inputs to load
+  ['#team-input', '#project-input'].forEach(sel => {
+    const el = $(sel);
+    if (el) el.addEventListener('keydown', (e) => { if (e.key === 'Enter') loadData(); });
+  });
+
+  // live preview on tab switch already handled
+  console.log('[editor] ready (vanilla, no jQuery)');
+}
+
+init();

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -524,6 +524,10 @@ function bindAddButtons() {
     if (e.target.matches('[data-add="p-cardStatus"]')) addKeyValueRepeat('p-cardStatus-container', 'projectData.cardStatus');
     if (e.target.matches('[data-add="p-timelines"]')) addTimeline();
     if (e.target.matches('[data-add="interval"]')) addInterval();
+    if (e.target.matches('[data-import-csv]')) {
+      const target = e.target.getAttribute('data-import-csv');
+      _importCSVToKeyValue(target);
+    }
   });
 
   // copy buttons
@@ -560,6 +564,83 @@ function bindAddButtons() {
       setTimeout(() => e.target.textContent = orig, 1200);
     }
   });
+}
+
+function parseCSVForEditor(text) {
+  if (!text) return [];
+  const lines = text.replace(/\r/g, '').trim().split('\n');
+  if (lines.length < 2) return [];
+  const headerLine = lines[0];
+  const headers = splitCSVLineEditor(headerLine).map(h => h.toLowerCase().trim());
+  const result = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const values = splitCSVLineEditor(line);
+    const row = {};
+    headers.forEach((h, j) => { row[h] = (values[j] || '').trim(); });
+    result.push(row);
+  }
+  return result;
+}
+
+function splitCSVLineEditor(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result.map(v => v.replace(/^"|"$/g, '').trim());
+}
+
+function _importCSVToKeyValue(target) {
+  const arrPath = target === 'p-cardTypes' ? 'projectData.cardTypes' : 'projectData.cardStatus';
+  const containerId = target === 'p-cardTypes' ? 'p-cardTypes-container' : 'p-cardStatus-container';
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.csv,text/csv';
+  input.style.display = 'none';
+  document.body.appendChild(input);
+  input.onchange = (e) => {
+    const file = e.target.files[0];
+    if (!file) {
+      document.body.removeChild(input);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target.result;
+      const rows = parseCSVForEditor(text);
+      const arr = getPath(state, arrPath) || [];
+      let added = 0;
+      rows.forEach(r => {
+        const key = r.key || r.type || r.name || r.col1 || r[0] || '';
+        let value = r.value || r.count || r.points || r.col2 || r[1] || '0';
+        value = parseInt(value, 10) || 0;
+        if (key) {
+          arr.push({ key: String(key).trim(), value });
+          added++;
+        }
+      });
+      document.body.removeChild(input);
+      if (added > 0) {
+        renderKeyValueRepeat(containerId, arrPath);
+        updatePreview();
+      }
+    };
+    reader.readAsText(file);
+  };
+  input.click();
 }
 
 function initFromQuery() {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -9,6 +9,7 @@ import Store from './Store.js';
 import Board from './Board.js';
 import IntervalPlanner from './IntervalPlanner.js';
 import TimelineEditor from './TimelineEditor.js';
+import BoardAdapter from './BoardAdapter.js';
 
 new ThemeSwitcher().setup();
 
@@ -61,7 +62,7 @@ let timeline = null;
     }
     const getData = new GetData(team, project);
     getData.setup().then(([dashboard, project, intervals]) => {
-      const board = dashboard[0];
+      let modelInput = dashboard[0];
 
       const lastModifiedIntervals = intervals[1].headers.get('Last-Modified');
       const dateIntervals = new Date(lastModifiedIntervals);
@@ -70,15 +71,34 @@ let timeline = null;
       const dateProject = new Date(lastModifiedProject);
 
       if(dateIntervals > dateProject){
-        board.updatedDate = helper.mmddyyyy(lastModifiedIntervals);
+        modelInput.updatedDate = helper.mmddyyyy(lastModifiedIntervals);
       } else if(dateIntervals <= dateProject){
-        board.updatedDate = helper.mmddyyyy(lastModifiedProject);
+        modelInput.updatedDate = helper.mmddyyyy(lastModifiedProject);
       }
 
-      board.project = project[0].project;
-      board.intervals = intervals[0].intervals;
+      modelInput.project = project[0].project;
+      modelInput.intervals = intervals[0].intervals;
 
-      const model = new Model(board);
+      // Phase 0: BoardAdapter - if the interactive board has data (cards, intervals, or timelines),
+      // derive/enrich the dashboard data from it so charts reflect live board state.
+      // This is the key unification: create/edit via editor + board/CSV, see rich charts.
+      try {
+        const storeSnapshot = {
+          cards: store.getCards(),
+          intervals: store.getIntervals(),
+          timelines: store.getTimelines()
+        };
+        const hasBoardData = (storeSnapshot.cards && storeSnapshot.cards.length > 0) ||
+                             (storeSnapshot.intervals && storeSnapshot.intervals.length > 0) ||
+                             (storeSnapshot.timelines && storeSnapshot.timelines.length > 0);
+        if (hasBoardData) {
+          modelInput = BoardAdapter.toDashboardData(storeSnapshot, modelInput);
+        }
+      } catch (e) {
+        console.warn('BoardAdapter failed, falling back to JSON data', e);
+      }
+
+      const model = new Model(modelInput);
       const main = new Scrum('main', model);
       main.setup();
       window.addEventListener('pagehide', main.destroy);

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1173,6 +1173,45 @@ p.updatedBy {
   .timeline-wrap { padding: 16px; }
 }
 
+/* =============================================================
+   JSON Editor (standalone, reuses .shell, .row, .button, vars)
+   ============================================================= */
+.editor-wrap { padding: 24px 0 48px; }
+.editor-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; flex-wrap: wrap; gap: 8px; }
+.editor-header h1 { font-size: 1.25rem; margin: 0; }
+.editor-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.editor-controls input[type="text"] { width: 160px; }
+.editor-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.editor-tab-btn {
+  appearance: none; background: none; border: 1px solid transparent; padding: 8px 16px;
+  font-family: var(--font-sans); font-size: 0.9rem; color: var(--text-secondary);
+  border-bottom: 3px solid transparent; cursor: pointer;
+}
+.editor-tab-btn.is-active { color: var(--text-primary); border-bottom-color: var(--tab-active); font-weight: 600; }
+.editor-pane { display: none; }
+.editor-pane.is-active { display: block; }
+.editor-form label { display: block; font-size: 0.75rem; color: var(--text-muted); margin: 10px 0 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+.editor-form input[type="text"], .editor-form input[type="number"], .editor-form select {
+  width: 100%; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--surface); color: var(--text-primary); font-family: var(--font-sans); font-size: 0.9rem;
+}
+.editor-form input:focus, .editor-form select:focus { border-color: var(--tab-active); outline: none; }
+.repeat-section { margin: 12px 0; }
+.repeat-row { display: flex; gap: 6px; align-items: center; margin-bottom: 6px; padding: 6px; background: var(--surface-2); border-radius: 6px; }
+.repeat-row input, .repeat-row select { flex: 1; min-width: 0; }
+.repeat-row .remove-btn { appearance: none; border: none; background: none; color: var(--text-muted); font-size: 1.1rem; line-height: 1; cursor: pointer; padding: 2px 6px; }
+.repeat-row .remove-btn:hover { color: var(--c-hover); }
+.add-btn { font-size: 0.8rem; padding: 4px 10px; margin-top: 4px; }
+.editor-preview { position: sticky; top: 24px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-card); padding: 12px; box-shadow: var(--shadow-card); }
+.editor-preview pre { margin: 0; font-family: var(--font-mono); font-size: 0.75rem; line-height: 1.3; max-height: 520px; overflow: auto; background: var(--surface-2); padding: 10px; border-radius: 6px; white-space: pre; }
+.editor-preview .preview-label { font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; display: flex; justify-content: space-between; align-items: center; }
+.editor-copy-btn { font-size: 0.7rem; padding: 2px 8px; }
+.editor-note { font-size: 0.75rem; color: var(--text-muted); margin-top: 12px; }
+.collapsible { border: 1px solid var(--border-subtle); border-radius: 6px; margin-bottom: 8px; background: var(--surface-2); }
+.collapsible summary { padding: 8px 10px; cursor: pointer; font-weight: 500; user-select: none; }
+.collapsible[open] summary { border-bottom: 1px solid var(--border-subtle); }
+.collapsible-body { padding: 8px 10px; }
+
 /* ============================================================= */
 /* Tab bar                                                       */
 /* ============================================================= */

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -853,6 +853,19 @@ p.updatedBy {
   transition: color 160ms ease, border-color 160ms ease;
 }
 .board-load-more:hover { color: var(--text-secondary); border-color: var(--text-muted); }
+.board-import-btn {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.board-import-btn:hover { background: var(--border); color: var(--text-primary); }
 
 @media (max-width: 960px) {
   .board-columns { grid-template-columns: repeat(2, 1fr); }

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, 'app/dashboard.html'),
         landing: path.resolve(__dirname, 'app/index.html'),
+        editor: path.resolve(__dirname, 'app/editor.html'),
       },
     },
   },


### PR DESCRIPTION
Next Phase 0 slice after JSON editor (#74, now merged).

Implements CSV import per roadmap:
- Standalone in Board: 'Import CSV' button in Backlog column header. Supports columns title,type,points,blocked (flexible header names). Bulk adds via Store, auto-expands backlog view.
- Wired into Editor: 'Import CSV' next to +Add for cardTypes and cardStatus (supports key,value / type,count etc headers). Appends and refreshes live preview.
- Basic CSV parser (handles quotes, no external deps).
- Matches 'cards → Board' and 'into both the new editor and a standalone import flow'.

Verified: lint PASS, build PASS (editor bundle updated).

Closes #109