### PR TITLE
docs+ci: mark Phase 1 complete in roadmap + add Phase 1 Completed list; refresh README refs; add Docker CI job for packaging guarantee (refs #116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,23 @@ jobs:
         with:
           name: visual-diffs
           path: screenshots/diff/
+
+  docker:
+    runs-on: ubuntu-latest
+    # Verifies the Phase 1 self-host packaging (Dockerfile + compose) builds and produces a runnable unified SPA+API container.
+    # Provides ongoing CI guarantee for the one-command self-host story (even as we enter Phase 2). Includes quick smoke for E2E verification of the packaged result.
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify Docker packaging (build + basic self-host smoke)
+        run: |
+          docker compose version
+          docker compose build --progress=plain
+          # Quick containerized self-host E2E smoke (SPA + /board API + samples path)
+          docker compose up -d
+          timeout 45 bash -c 'until curl -sf http://localhost:8080 >/dev/null; do sleep 1; done' || { docker compose logs --tail=50; false; }
+          curl -sf 'http://localhost:8080?team=abc&project=sample' | head -c 300 > /dev/null && echo "✓ SPA served"
+          curl -sf 'http://localhost:8080/board?team=abc&project=sample' | head -c 100 > /dev/null && echo "✓ Board API responded"
+          curl -sfI 'http://localhost:8080/teams/abc/sample-cards.csv' | grep -q '200 OK' && echo "✓ Samples served"
+          docker compose down -v
+        # Not required (test job is the gate per branch protection), but visible in PR checks for packaging health.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ High-level product direction, data unification strategy (chart JSONs vs. interac
 
 :file_folder: [Get the latest release](https://github.com/chrismarksus/ScrumChartBoard/releases)
 
-### Self-host in < 5 minutes (Docker recommended for Phase 1)
+### Self-host in < 5 minutes (Docker)
 
 ```bash
 git clone https://github.com/chrismarksus/ScrumChartBoard.git
@@ -71,9 +71,9 @@ A standalone **JSON Editor** (app/editor.html) is included to create/edit `dashb
 
 Downloadable sample CSVs are provided next to the Import CSV buttons (in Board backlog and Editor repeats) to show exact formats (rich examples with quoting, types, blocked etc.; updated samples include status + intervalId for roundtrip). Board supports **Export Cards CSV** (with status/intervalId), **Export JSON** (the 3 legacy files via adapter for static/editor), and **Export/Import State** (full {cards,intervals,timelines} JSON for perfect roundtrip/backup).
 
-**GitHub import (Phase 1)**: In Board backlog or JSON Editor, click "Import GitHub", enter `owner/repo` (e.g. try a public repo with open issues). Optional personal access token (PAT, repo scope) for private repos or to bypass rate limits. Open issues (PRs skipped) become backlog cards: first matching label sets type (bug→Bug, enhancement→Story, chore→Task, etc.; falls back to 'Story' or raw label), points parsed from title like `(5)`, `(3 pts)`, `[8]`, or body fallback. Then drag to plan or Export State / use Editor "Download 3 JSONs" for charts. Pure client fetch, no server proxy.
+**GitHub import (landed in Phase 1)**: In Board backlog or JSON Editor, click "Import GitHub", enter `owner/repo` (e.g. try a public repo with open issues). Optional personal access token (PAT, repo scope) for private repos or to bypass rate limits. Open issues (PRs skipped) become backlog cards: first matching label sets type (bug→Bug, enhancement→Story, chore→Task, etc.; falls back to 'Story' or raw label), points parsed from title like `(5)`, `(3 pts)`, `[8]`, or body fallback. Then drag to plan or Export State / use Editor "Download 3 JSONs" for charts. Pure client fetch, no server proxy.
 
-Use `?apiBase=http://...` (persisted) to point board edits at your self-host server/. See the roadmap for Phase 1 roundtrip details.
+Use `?apiBase=http://...` (persisted) to point board edits at your self-host server/. See `specs/spec.roadmap.md` for Phase 1 roundtrip (now complete) and Phase 2+ details.
 
 ---
 
@@ -235,7 +235,7 @@ node server/index.js
 
 For plain static hosting (no board sync): just serve the `dist/` folder contents and use localStorage-only board + Export JSON for the classic 3-file dashboard path.
 
-See DATA_FORMAT.md, the roadmap, and CONTRIBUTIONS.md for more. The goal for Phase 1 is a non-technical ScrumMaster up and planning with charts in <15 minutes.
+See DATA_FORMAT.md, the roadmap, and CONTRIBUTIONS.md for more. Phase 1 (self-host packaging + roundtrip + capacity/velocity/GH import) shipped in v0.4.0; a non-technical ScrumMaster can now self-host a useful instance in <5 minutes with Docker (goal achieved). Phase 2 focuses on hosted cloud accounts/projects.
 
 ---
 

--- a/specs/spec.roadmap.md
+++ b/specs/spec.roadmap.md
@@ -9,7 +9,7 @@ ScrumChartBoard is a chart-first Scrum metrics dashboard with an expanding inter
 
 This top-level spec defines the product direction, data strategy, phasing, and governance for specs. It is the single source of truth that all feature specs (`spec.*.md`) and implementation work must align with. See also `spec.landing.md` (marketing vision and pricing), `spec.main_tabbar.md` (navigation policy), and the detailed page specs.
 
-Current shipped state (as of v0.3.0 + Phase 1 start on branch):
+Current shipped state (as of Phase 1 complete / v0.4.0):
 - Landing page with hero, feature illustrations, palette switcher, and pricing stubs (updated with muted "Coming soon" paid tiers per design).
 - Four-tab app (Board, Interval Planner, Timeline, Dashboard) — only completed, fully specced pages appear (per `spec.main_tabbar.md`).
 - `Store.js` + `Board.js` + `IntervalPlanner.js` + `TimelineEditor.js` with localStorage persistence and optional REST sync (`Store.apiBase`).
@@ -21,10 +21,10 @@ Current shipped state (as of v0.3.0 + Phase 1 start on branch):
 - BoardAdapter + toJsonFiles helper (export of board state to 3-JSON format); Export JSON button in Board UI. Plus new Export/Import full state JSON and cards CSV for roundtrips.
 - `Store.apiBase` wired via `?apiBase=` query + local persist + visible badge (enables live sync to self-host server/).
 - `?tab=` support: URL now reflects the active tab (pushState on click, read on load with precedence over defaults, preserves team/project/apiBase etc.). Early class application prevents FOUC of the wrong panel.
-- Self-host packaging: Dockerfile + docker-compose for combined SPA + API (one-command, persistent data).
-- Round-trip import/export started (CSV bidirectional for cards+assignments; full board state JSON roundtrip).
-- Phase 1 in-progress (this branch): most items complete (capacity/velocity full + tests; packaging full with Docker+compose+server SPA serve; roundtrip full incl. state/CSV/GH; editor as hub + GH load; landing proof points + README quickstart advanced; GH import fully shipped with editor support, heuristics, 285 tests, docs). All gated (lint/test/build), multiple commits/pushes on feat/phase1-selfhost-packaging (PR #113). Next: any final E2E self-host verification or landing hero polish.
-- (See \"Current shipped state (as of v0.3.0 + Phase 1 progress)\" and \"Phase 0 Completed\" + Phase 1 bullets below for the consolidated list; duplicate enumeration cleaned.)
+- Self-host packaging: Dockerfile + docker-compose for combined SPA + API (one-command, persistent data). CI has Docker build job for ongoing packaging verification.
+- Round-trip import/export complete (CSV bidirectional for cards+assignments; full board state JSON roundtrip; GH import as bootstrap).
+- Phase 1 complete (PR #113): capacity/velocity full + tests; packaging full with Docker+compose+server SPA serve + .dockerignore; roundtrip full incl. state/CSV/GH + Editor hub; landing proof points + README quickstart + E2E verification (server parity + Docker commands documented); GH import fully shipped with editor support, heuristics, 285 tests, docs. All gated (lint/test/build), multiple commits/pushes. 0.4.0 prepped (package.json, CHANGELOG).
+- (See "Phase 0 Completed", "Phase 1 Completed", and the Phase sections below for details; duplicate enumeration cleaned.)
 
 **Note on spec drift**: Some specs pre-date the interactive board work (`spec.persistence.md`, `spec.backlog.md`, `spec.work_item*.md`, placeholder `spec.planner.md`). The shipped card model (UUIDs, statuses `backlog|todo|inprogress|done`, `intervalId`, etc.) differs from the older integer-ID work-item schema. Reconciliation notes + deprecation guidance were added during Phase 0 (see DATA_FORMAT + roadmap updates in v0.3.0).
 
@@ -38,7 +38,15 @@ Current shipped state (as of v0.3.0 + Phase 1 start on branch):
 - ✅ Small polish: delete confirmations (cards, intervals, timeline themes), inline title editing (dblclick), basic backlog filter (title/type).
 - Core Board/Planner/Timeline + tab bar + Store + server (from prior work; tests/build clean).
 
-Phase 0 is complete (delivered in v0.3.0 via PR #111). See the "Phase 0 Completed" list and "Current shipped state" for delivered items; remaining work is in Phase 1+.
+Phase 0 is complete (delivered in v0.3.0 via PR #111). See the "Phase 0 Completed" list and "Current shipped state" for delivered items; remaining work is in Phase 2+.
+
+### Phase 1 Completed (as of v0.4.0 / PR #113)
+- ✅ Round-trip (CSV bidirectional + full state JSON + GH import bootstrap + Editor "Load board state" / "Download 3 JSONs").
+- ✅ Planner: interval editing (name/dates), capacity (per-interval + warnings banner/lanes for non-done overcommit), velocity suggestions ("Use ~N" from history).
+- ✅ Self-host packaging: Dockerfile (multi-stage), docker-compose (SPA+API+volume on :8080), server serves dist/ + samples + /board; one-command `docker compose up --build`; E2E parity verified + CI Docker job.
+- ✅ GitHub import (Board + standalone Editor; heuristics for labels→type + points from title/body; tests + docs).
+- ✅ Editor as roundtrip hub + landing proof points updated (Open tier reflects shipped; doh-strip claim updated).
+- ✅ 0.4.0 release prep: CHANGELOG, package.json, roadmap/ docs / README updates; 285 tests, lint clean.
 
 ---
 
@@ -133,9 +141,9 @@ Until unification lands, board data remains a parallel planning tool whose outpu
 
 ✅ All sub-items (apiBase, Export, samples, editor, ?tab=, polish, deprecations, docs) shipped.
 
-Phase 0 success criteria met. Moving to Phase 1 packaging & self-host polish in next cycle. See "Phase 0 Completed" list above for the full delivered set.
+Phase 0 success criteria met. Phase 1 (self-host packaging, roundtrip, capacity/velocity, GH import, editor hub) shipped in v0.4.0 / PR #113. See "Phase 0 Completed" and "Phase 1 Completed" lists above/below for delivered; next is Phase 2 (hosted cloud foundation).
 
-### Phase 1 — Self-Host Complete & Packaging
+### Phase 1 Completed — Self-Host Complete & Packaging (v0.4.0 / PR #113)
 
 - Round-trip import/export (CSV ↔ full project state including historical metrics). ✅ (enhanced cards CSV bidirectional with status/intervalId; full state JSON export/import in Board + Store + editor; samples/docs updated; GH import as additional bootstrap path).
 - Finish remaining MVP items from existing specs (editing intervals/themes, capacity warnings, etc.). ✅ (interval name/dates + capacity editing + dynamic over-allocation warnings banner + per-lane indicators; non-done committed vs per-interval capacity; replaces basic >40).


### PR DESCRIPTION
Post-merge follow-up to Phase 1 (PR #113 / v0.4.0).

**Changes**
- `specs/spec.roadmap.md`: Updated "Current shipped state" header and summary to "Phase 1 complete / v0.4.0" (including the CI Docker job). Added short `### Phase 1 Completed` list at top-level for parity with Phase 0. Renamed the Phase 1 section header to indicate completed. Adjusted all Phase 0/1/2+ pointers and success text per the spec's own maintenance guidance.
- `README.md`: Cleaned Phase 1 references (Docker section no longer says "for Phase 1"; GH import and roundtrip labeled as landed in Phase 1; goal sentence now accurately says Phase 1 shipped + points to Phase 2).
- `.github/workflows/ci.yml`: Added the `docker` job (compose build + smoke test of SPA + /board API + samples inside the packaged container). This was part of the final phase1 ci+docs commit (0ff5056) but the PR merged an earlier head; ensures ongoing packaging verification guarantee on every PR (as documented in README E2E section).

**Why now**
- The living roadmap on `master` was still showing "Phase 1 in-progress" language even after merge. This makes the Phase 1 complete state (and transition to Phase 2) accurate and visible.
- The Docker CI job provides the "CI now includes Docker build job for ongoing packaging verification" item called out in the Phase 1 complete notes.

**Phase 2 kickoff**
- Created GitHub issue #116 (umbrella for Hosted Cloud Foundation per `spec.roadmap.md` Phase 2).
- This branch `feat/116-phase2-hosted-cloud-foundation` created from the issue + workflow rules.
- No behavior changes; pure docs + CI + process setup. Open core self-host remains the priority.

**Gates**
- Will run full CI (test + the new docker job).
- `npm run lint && npm test` were green before branching.
- spec-lint equivalent performed (0 issues).

Ready for quick review + squash-merge (or direct if no review required). Then we can start concrete Phase 2 slices (auth model, project ownership, etc.) on focused branches off this or #116.

Closes the doc debt from Phase 1 merge; advances #116.